### PR TITLE
chore(ci): add hive consume tests workflow

### DIFF
--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -40,26 +40,26 @@ jobs:
     steps:
       - name: Checkout execution-specs
         if: matrix.mode == 'dev'
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           path: execution-specs
 
       - name: Checkout Hive
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: ethereum/hive
           ref: master
           path: hive
 
       - name: Setup go env and cache
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: '>=1.24'
           cache-dependency-path: hive/go.sum
 
       - name: Setup Python
         if: matrix.mode == 'dev'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -7,9 +7,12 @@ on:
   pull_request:
     paths:
       - '.github/workflows/hive-consume.yaml'
-      - 'packages/tests/src/pytest_plugins/consume/**'
-      - 'packages/tests/src/pytest_plugins/pytest_hive/**'
+      - 'packages/testing/src/execution_testing/cli/pytest_commands/consume.py'
+      - 'packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-consume.ini'
       - 'packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/**'
+      - 'packages/testing/src/execution_testing/cli/pytest_commands/plugins/pytest_hive/**'
+      - 'packages/testing/src/execution_testing/fixtures/consume.py'
+      - 'packages/testing/src/execution_testing/rpc/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -5,12 +5,11 @@ on:
     branches:
       - 'forks/**'
   pull_request:
-    # TODO: After initial testing, uncomment these paths to only run on relevant changes:
-    # paths:
-    #   - '.github/workflows/hive-consume.yaml'
-    #   - 'packages/tests/src/pytest_plugins/consume/**'
-    #   - 'packages/tests/src/pytest_plugins/pytest_hive/**'
-    #   - 'packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/**'
+    paths:
+      - '.github/workflows/hive-consume.yaml'
+      - 'packages/tests/src/pytest_plugins/consume/**'
+      - 'packages/tests/src/pytest_plugins/pytest_hive/**'
+      - 'packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -59,17 +59,14 @@ jobs:
           go-version: '>=1.24'
           cache-dependency-path: hive/go.sum
 
-      - name: Setup Python
+      - name: Install uv and python
         if: matrix.mode == 'dev'
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182
         with:
-          python-version: '3.12'
-
-      - name: Install uv
-        if: matrix.mode == 'dev'
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          enable-cache: true
+          cache-dependency-glob: "execution-specs/uv.lock"
+          version: ${{ vars.UV_VERSION }}
+          python-version: ${{ vars.DEFAULT_PYTHON_VERSION }}
 
       - name: Pre-pull geth docker image
         run: docker pull docker.ethquokkaops.io/dh/ethpandaops/geth:master

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -94,7 +94,7 @@ jobs:
             --sim.parallelism=1 \
             --client go-ethereum \
             --client-file clients.yaml \
-            --sim.buildarg fixtures=develop@latest \
+            --sim.buildarg fixtures=develop@v5.3.0 \
             --sim.limit=".*test_block_at_rlp_limit_with_logs.*Osaka.*" \
             --docker.output
 
@@ -120,4 +120,4 @@ jobs:
           HIVE_SIMULATOR: http://127.0.0.1:3000
         run: |
           uv sync --all-extras
-          uv run consume ${{ matrix.consume_command }} --input develop@latest -k "Osaka and test_block_at_rlp_limit_with_logs"
+          uv run consume ${{ matrix.consume_command }} --input develop@v5.3.0 -k "Osaka and test_block_at_rlp_limit_with_logs"

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -1,0 +1,124 @@
+name: Hive Consume Tests
+
+on:
+  push:
+    branches:
+      - 'forks/**'
+  pull_request:
+    # TODO: After initial testing, uncomment these paths to only run on relevant changes:
+    # paths:
+    #   - '.github/workflows/hive-consume.yaml'
+    #   - 'packages/tests/src/pytest_plugins/consume/**'
+    #   - 'packages/tests/src/pytest_plugins/pytest_hive/**'
+    #   - 'packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/**'
+  workflow_dispatch:
+
+concurrency:
+  group: hive-consume-${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test-hive:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - name: consume-engine
+            mode: simulator
+            simulator: ethereum/eels/consume-engine
+          - name: consume-rlp
+            mode: simulator
+            simulator: ethereum/eels/consume-rlp
+          - name: consume-sync
+            mode: simulator
+            simulator: ethereum/eels/consume-sync
+          - name: dev-mode
+            mode: dev
+            consume_command: engine
+    steps:
+      - name: Checkout execution-specs
+        if: matrix.mode == 'dev'
+        uses: actions/checkout@v5
+        with:
+          path: execution-specs
+
+      - name: Checkout Hive
+        uses: actions/checkout@v5
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+
+      - name: Setup go env and cache
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.24'
+          cache-dependency-path: hive/go.sum
+
+      - name: Setup Python
+        if: matrix.mode == 'dev'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        if: matrix.mode == 'dev'
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Pre-pull geth docker image
+        run: docker pull docker.ethquokkaops.io/dh/ethpandaops/geth:master
+
+      - name: Create clients.yaml
+        run: |
+          cat > hive/clients.yaml << 'EOF'
+          - client: go-ethereum
+            nametag: default
+            build_args:
+              baseimage: docker.ethquokkaops.io/dh/ethpandaops/geth
+              tag: master
+          EOF
+
+      - name: Build hive
+        run: |
+          cd hive
+          go build .
+
+      - name: Run simulator tests
+        if: matrix.mode == 'simulator'
+        run: |
+          cd hive
+          ./hive --sim '${{ matrix.simulator }}' \
+            --sim.parallelism=1 \
+            --client go-ethereum \
+            --client-file clients.yaml \
+            --sim.buildarg fixtures=develop@latest \
+            --sim.limit=".*test_block_at_rlp_limit_with_logs.*Osaka.*" \
+            --docker.output
+
+      - name: Start Hive in dev mode
+        if: matrix.mode == 'dev'
+        run: |
+          cd hive
+          ./hive --dev --client go-ethereum --client-file clients.yaml --docker.output &
+          echo "Waiting for Hive to be ready..."
+          for i in {1..30}; do
+            if curl -s http://127.0.0.1:3000 > /dev/null 2>&1; then
+              echo "Hive is ready!"
+              break
+            fi
+            echo "Waiting... ($i/30)"
+            sleep 2
+          done
+
+      - name: Run consume in dev mode
+        if: matrix.mode == 'dev'
+        working-directory: execution-specs
+        env:
+          HIVE_SIMULATOR: http://127.0.0.1:3000
+        run: |
+          uv sync --all-extras
+          uv run consume ${{ matrix.consume_command }} --input develop@latest -k "Osaka and test_block_at_rlp_limit_with_logs"

--- a/packages/testing/src/execution_testing/cli/eofwrap.py
+++ b/packages/testing/src/execution_testing/cli/eofwrap.py
@@ -323,6 +323,7 @@ class EofWrapper:
 
         test = BlockchainTest(
             genesis_environment=env,
+            fork=EOFv1,
             pre=pre.root,
             post=fixture.post_state.root if fixture.post_state else {},
             blocks=[],
@@ -373,7 +374,6 @@ class EofWrapper:
 
         result = test.generate(
             t8n=t8n,
-            fork=EOFv1,
             fixture_format=BlockchainFixture,
         )
         assert isinstance(result, BlockchainFixture)

--- a/packages/testing/src/execution_testing/cli/fuzzer_bridge/blocktest_builder.py
+++ b/packages/testing/src/execution_testing/cli/fuzzer_bridge/blocktest_builder.py
@@ -68,7 +68,6 @@ class BlocktestBuilder:
         # Generate fixture
         fixture = test.generate(
             t8n=self.t8n,
-            fork=fork,
             fixture_format=BlockchainFixture,
         )
 

--- a/packages/testing/src/execution_testing/cli/fuzzer_bridge/converter.py
+++ b/packages/testing/src/execution_testing/cli/fuzzer_bridge/converter.py
@@ -251,6 +251,7 @@ def blockchain_test_from_fuzzer(
 
     return BlockchainTest(
         pre=pre,
+        fork=fork,
         blocks=blocks,
         post={},  # Post-state verification can be added later
         genesis_environment=genesis_env,

--- a/packages/testing/src/execution_testing/cli/fuzzer_bridge/production_test.py
+++ b/packages/testing/src/execution_testing/cli/fuzzer_bridge/production_test.py
@@ -201,6 +201,7 @@ class FuzzerBridge:
         # Create test
         test = BlockchainTest(
             genesis_environment=test_params["genesis_environment"],
+            fork=fork,
             pre=test_params["pre"],
             post=test_params["post"],
             blocks=test_params["blocks"],
@@ -210,7 +211,6 @@ class FuzzerBridge:
         # Generate fixture
         fixture = test.generate(
             t8n=self.t8n,
-            fork=fork,
             fixture_format=BlockchainFixture,
         )
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
@@ -407,6 +407,7 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     kwargs["expected_benchmark_gas_used"] = (
                         request.getfixturevalue("gas_benchmark_value")
                     )
+                kwargs["fork"] = fork
                 kwargs |= {
                     p: request.getfixturevalue(p)
                     for p in cls_fixture_parameters
@@ -436,9 +437,7 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     [str(eoa) for eoa in pre._funded_eoa]
                 )
 
-                execute = self.execute(
-                    fork=fork, execute_format=execute_format
-                )
+                execute = self.execute(execute_format=execute_format)
                 execute.execute(
                     fork=fork,
                     eth_rpc=eth_rpc,

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -28,11 +28,11 @@ from execution_testing.base_types import (
     Alloc,
     ReferenceSpec,
 )
-from execution_testing.client_clis import TransitionTool
-from execution_testing.client_clis.clis.geth import FixtureConsumerTool
 from execution_testing.cli.gen_index import (
     generate_fixtures_index,
 )
+from execution_testing.client_clis import TransitionTool
+from execution_testing.client_clis.clis.geth import FixtureConsumerTool
 from execution_testing.fixtures import (
     BaseFixture,
     FixtureCollector,
@@ -1350,6 +1350,7 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     kwargs["pre"] = pre
                 if "expected_benchmark_gas_used" not in kwargs:
                     kwargs["expected_benchmark_gas_used"] = gas_benchmark_value
+                kwargs["fork"] = fork
                 kwargs |= {
                     p: request.getfixturevalue(p)
                     for p in cls_fixture_parameters
@@ -1380,7 +1381,7 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     # Use the original update_pre_alloc_groups method which
                     # returns the groups
                     self.update_pre_alloc_groups(
-                        session.pre_alloc_groups, fork, request.node.nodeid
+                        session.pre_alloc_groups, request.node.nodeid
                     )
                     return  # Skip fixture generation in phase 1
 
@@ -1391,15 +1392,12 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     FixtureFillingPhase.PRE_ALLOC_GENERATION
                     in fixture_format.format_phases
                 ):
-                    pre_alloc_hash = self.compute_pre_alloc_group_hash(
-                        fork=fork
-                    )
+                    pre_alloc_hash = self.compute_pre_alloc_group_hash()
                     group = session.get_pre_alloc_group(pre_alloc_hash)
                     self.pre = group.pre
                 try:
                     fixture = self.generate(
                         t8n=t8n,
-                        fork=fork,
                         fixture_format=fixture_format,
                     )
                 finally:

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_prealloc_group.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_prealloc_group.py
@@ -24,12 +24,14 @@ class MockTest(BaseTest):
     def __init__(
         self,
         pre: Alloc,
+        fork: Fork,
         genesis_environment: Environment,
         request: Mock | None = None,
     ) -> None:
         """Initialize mock test."""
         super().__init__(  # type: ignore
             pre=pre,
+            fork=fork,
             genesis_environment=genesis_environment,
         )
         self._request = request
@@ -38,9 +40,9 @@ class MockTest(BaseTest):
         """Mock generate method."""
         raise NotImplementedError("This is a mock test class")
 
-    def get_genesis_environment(self, fork: Fork) -> Environment:
+    def get_genesis_environment(self) -> Environment:
         """Return the genesis environment."""
-        return self.genesis_environment.set_fork_requirements(fork)
+        return self.genesis_environment.set_fork_requirements(self.fork)
 
 
 def test_pre_alloc_group_separate() -> None:
@@ -51,8 +53,8 @@ def test_pre_alloc_group_separate() -> None:
     fork = Prague
 
     # Create test without marker
-    test1 = MockTest(pre=pre, genesis_environment=env)
-    hash1 = test1.compute_pre_alloc_group_hash(fork)
+    test1 = MockTest(pre=pre, genesis_environment=env, fork=fork)
+    hash1 = test1.compute_pre_alloc_group_hash()
 
     # Create test with "separate" marker
     mock_request = Mock()
@@ -62,15 +64,17 @@ def test_pre_alloc_group_separate() -> None:
     mock_marker.args = ("separate",)
     mock_request.node.get_closest_marker = Mock(return_value=mock_marker)
 
-    test2 = MockTest(pre=pre, genesis_environment=env, request=mock_request)
-    hash2 = test2.compute_pre_alloc_group_hash(fork)
+    test2 = MockTest(
+        pre=pre, genesis_environment=env, request=mock_request, fork=fork
+    )
+    hash2 = test2.compute_pre_alloc_group_hash()
 
     # Hashes should be different due to "separate" marker
     assert hash1 != hash2
 
     # Create another test without marker - should match first test
-    test3 = MockTest(pre=pre, genesis_environment=env)
-    hash3 = test3.compute_pre_alloc_group_hash(fork)
+    test3 = MockTest(pre=pre, genesis_environment=env, fork=fork)
+    hash3 = test3.compute_pre_alloc_group_hash()
 
     assert hash1 == hash3
 
@@ -89,8 +93,10 @@ def test_pre_alloc_group_custom_salt() -> None:
     mock_marker1.args = ("eip1234",)
     mock_request1.node.get_closest_marker = Mock(return_value=mock_marker1)
 
-    test1 = MockTest(pre=pre, genesis_environment=env, request=mock_request1)
-    hash1 = test1.compute_pre_alloc_group_hash(fork)
+    test1 = MockTest(
+        pre=pre, genesis_environment=env, request=mock_request1, fork=fork
+    )
+    hash1 = test1.compute_pre_alloc_group_hash()
 
     # Create another test with same custom group "eip1234"
     mock_request2 = Mock()
@@ -102,8 +108,10 @@ def test_pre_alloc_group_custom_salt() -> None:
     mock_marker2.args = ("eip1234",)  # Same group
     mock_request2.node.get_closest_marker = Mock(return_value=mock_marker2)
 
-    test2 = MockTest(pre=pre, genesis_environment=env, request=mock_request2)
-    hash2 = test2.compute_pre_alloc_group_hash(fork)
+    test2 = MockTest(
+        pre=pre, genesis_environment=env, request=mock_request2, fork=fork
+    )
+    hash2 = test2.compute_pre_alloc_group_hash()
 
     # Hashes should be the same - both in "eip1234" group
     assert hash1 == hash2
@@ -116,8 +124,10 @@ def test_pre_alloc_group_custom_salt() -> None:
     mock_marker3.args = ("eip5678",)  # Different group
     mock_request3.node.get_closest_marker = Mock(return_value=mock_marker3)
 
-    test3 = MockTest(pre=pre, genesis_environment=env, request=mock_request3)
-    hash3 = test3.compute_pre_alloc_group_hash(fork)
+    test3 = MockTest(
+        pre=pre, genesis_environment=env, request=mock_request3, fork=fork
+    )
+    hash3 = test3.compute_pre_alloc_group_hash()
 
     # Hash should be different - different custom group
     assert hash1 != hash3
@@ -138,8 +148,10 @@ def test_pre_alloc_group_separate_different_nodeids() -> None:
     mock_marker1.args = ("separate",)
     mock_request1.node.get_closest_marker = Mock(return_value=mock_marker1)
 
-    test1 = MockTest(pre=pre, genesis_environment=env, request=mock_request1)
-    hash1 = test1.compute_pre_alloc_group_hash(fork)
+    test1 = MockTest(
+        pre=pre, genesis_environment=env, request=mock_request1, fork=fork
+    )
+    hash1 = test1.compute_pre_alloc_group_hash()
 
     # Create test with "separate" and nodeid2
     mock_request2 = Mock()
@@ -149,8 +161,10 @@ def test_pre_alloc_group_separate_different_nodeids() -> None:
     mock_marker2.args = ("separate",)
     mock_request2.node.get_closest_marker = Mock(return_value=mock_marker2)
 
-    test2 = MockTest(pre=pre, genesis_environment=env, request=mock_request2)
-    hash2 = test2.compute_pre_alloc_group_hash(fork)
+    test2 = MockTest(
+        pre=pre, genesis_environment=env, request=mock_request2, fork=fork
+    )
+    hash2 = test2.compute_pre_alloc_group_hash()
 
     # Hashes should be different due to different nodeids
     assert hash1 != hash2
@@ -168,12 +182,14 @@ def test_no_pre_alloc_group_marker() -> None:
     mock_request.node.nodeid = "test_module.py::test_function"
     mock_request.node.get_closest_marker = Mock(return_value=None)  # No marker
 
-    test1 = MockTest(pre=pre, genesis_environment=env, request=mock_request)
-    hash1 = test1.compute_pre_alloc_group_hash(fork)
+    test1 = MockTest(
+        pre=pre, genesis_environment=env, request=mock_request, fork=fork
+    )
+    hash1 = test1.compute_pre_alloc_group_hash()
 
     # Create test without any request
-    test2 = MockTest(pre=pre, genesis_environment=env)
-    hash2 = test2.compute_pre_alloc_group_hash(fork)
+    test2 = MockTest(pre=pre, genesis_environment=env, fork=fork)
+    hash2 = test2.compute_pre_alloc_group_hash()
 
     # Hashes should be the same - both have no marker
     assert hash1 == hash2
@@ -196,8 +212,10 @@ def test_pre_alloc_group_with_reason() -> None:
     }
     mock_request1.node.get_closest_marker = Mock(return_value=mock_marker1)
 
-    test1 = MockTest(pre=pre, genesis_environment=env, request=mock_request1)
-    hash1 = test1.compute_pre_alloc_group_hash(fork)
+    test1 = MockTest(
+        pre=pre, genesis_environment=env, request=mock_request1, fork=fork
+    )
+    hash1 = test1.compute_pre_alloc_group_hash()
 
     # Create another test with same group but different reason
     mock_request2 = Mock()
@@ -208,8 +226,10 @@ def test_pre_alloc_group_with_reason() -> None:
     mock_marker2.kwargs = {"reason": "Different reason but same group"}
     mock_request2.node.get_closest_marker = Mock(return_value=mock_marker2)
 
-    test2 = MockTest(pre=pre, genesis_environment=env, request=mock_request2)
-    hash2 = test2.compute_pre_alloc_group_hash(fork)
+    test2 = MockTest(
+        pre=pre, genesis_environment=env, request=mock_request2, fork=fork
+    )
+    hash2 = test2.compute_pre_alloc_group_hash()
 
     # Hashes should be the same - reason doesn't affect grouping
     assert hash1 == hash2

--- a/packages/testing/src/execution_testing/client_clis/clis/besu.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/besu.py
@@ -296,26 +296,6 @@ class BesuExceptionMapper(ExceptionMapper):
         BlockException.RLP_BLOCK_LIMIT_EXCEEDED: (
             r"Block size of \d+ bytes exceeds limit of \d+ bytes"
         ),
-        BlockException.INVALID_BAL_EXTRA_ACCOUNT: (
-            r"Block access list hash mismatch, "
-            r"calculated:\s*(0x[a-f0-9]+)\s+header:\s*(0x[a-f0-9]+)"
-        ),
-        BlockException.INVALID_BAL_HASH: (
-            r"Block access list hash mismatch, "
-            r"calculated:\s*(0x[a-f0-9]+)\s+header:\s*(0x[a-f0-9]+)"
-        ),
-        BlockException.INVALID_BAL_MISSING_ACCOUNT: (
-            r"Block access list hash mismatch, "
-            r"calculated:\s*(0x[a-f0-9]+)\s+header:\s*(0x[a-f0-9]+)"
-        ),
-        BlockException.INVALID_BLOCK_ACCESS_LIST: (
-            r"Block access list hash mismatch, "
-            r"calculated:\s*(0x[a-f0-9]+)\s+header:\s*(0x[a-f0-9]+)"
-        ),
-        BlockException.INCORRECT_BLOCK_FORMAT: (
-            r"Block access list hash mismatch, "
-            r"calculated:\s*(0x[a-f0-9]+)\s+header:\s*(0x[a-f0-9]+)"
-        ),
         TransactionException.INITCODE_SIZE_EXCEEDED: (
             r"transaction invalid Initcode size of \d+ exceeds maximum size of \d+"
         ),
@@ -344,5 +324,26 @@ class BesuExceptionMapper(ExceptionMapper):
         ),
         TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: (
             r"Blob transaction has too many blobs: \d+|Invalid Blob Count: \d+"
+        ),
+        # BAL Exceptions: TODO - review once all clients completed.
+        BlockException.INVALID_BAL_EXTRA_ACCOUNT: (
+            r"Block access list hash mismatch, "
+            r"calculated:\s*(0x[a-f0-9]+)\s+header:\s*(0x[a-f0-9]+)"
+        ),
+        BlockException.INVALID_BAL_HASH: (
+            r"Block access list hash mismatch, "
+            r"calculated:\s*(0x[a-f0-9]+)\s+header:\s*(0x[a-f0-9]+)"
+        ),
+        BlockException.INVALID_BAL_MISSING_ACCOUNT: (
+            r"Block access list hash mismatch, "
+            r"calculated:\s*(0x[a-f0-9]+)\s+header:\s*(0x[a-f0-9]+)"
+        ),
+        BlockException.INVALID_BLOCK_ACCESS_LIST: (
+            r"Block access list hash mismatch, "
+            r"calculated:\s*(0x[a-f0-9]+)\s+header:\s*(0x[a-f0-9]+)"
+        ),
+        BlockException.INCORRECT_BLOCK_FORMAT: (
+            r"Block access list hash mismatch, "
+            r"calculated:\s*(0x[a-f0-9]+)\s+header:\s*(0x[a-f0-9]+)"
         ),
     }

--- a/packages/testing/src/execution_testing/client_clis/clis/geth.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/geth.py
@@ -87,9 +87,6 @@ class GethExceptionMapper(ExceptionMapper):
         BlockException.SYSTEM_CONTRACT_CALL_FAILED: "system call failed to execute:",
         BlockException.INVALID_BLOCK_HASH: "blockhash mismatch",
         BlockException.RLP_BLOCK_LIMIT_EXCEEDED: "block RLP-encoded size exceeds maximum",
-        BlockException.INVALID_BAL_EXTRA_ACCOUNT: "BAL change not reported in computed",
-        BlockException.INVALID_BAL_MISSING_ACCOUNT: "additional mutations compared to BAL",
-        BlockException.INVALID_BLOCK_ACCESS_LIST: "unequal",
     }
     mapping_regex: ClassVar[Dict[ExceptionBase, str]] = {
         TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
@@ -116,6 +113,19 @@ class GethExceptionMapper(ExceptionMapper):
         #
         # EELS definition for `is_valid_deposit_event_data`:
         # https://github.com/ethereum/execution-specs/blob/5ddb904fa7ba27daeff423e78466744c51e8cb6a/src/ethereum/forks/prague/requests.py#L51
+        # BAL Exceptions: TODO - review once all clients completed.
+        BlockException.INVALID_BAL_EXTRA_ACCOUNT: (
+            r"invalid block access list:"
+        ),
+        BlockException.INVALID_BAL_HASH: (r"invalid block access list:"),
+        BlockException.INVALID_BAL_MISSING_ACCOUNT: (
+            r"computed state diff contained mutated accounts which weren't reported in BAL"
+        ),
+        BlockException.INVALID_BLOCK_ACCESS_LIST: (
+            r"difference between computed state diff and BAL entry for account"
+            r"|invalid block access list:"
+        ),
+        BlockException.INCORRECT_BLOCK_FORMAT: (r"invalid block access list:"),
     }
 
 

--- a/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
@@ -455,4 +455,19 @@ class NethermindExceptionMapper(ExceptionMapper):
         BlockException.SYSTEM_CONTRACT_CALL_FAILED: (
             r"(Withdrawals|Consolidations)Failed: Contract execution failed\."
         ),
+        # BAL Exceptions: TODO - review once all clients completed.
+        BlockException.INVALID_BAL_EXTRA_ACCOUNT: (
+            r"could not be parsed as a block: Could not decode block access list."
+        ),
+        BlockException.INVALID_BAL_HASH: (r"InvalidBlockLevelAccessListRoot:"),
+        BlockException.INVALID_BAL_MISSING_ACCOUNT: (
+            r"InvalidBlockLevelAccessListRoot:"
+        ),
+        BlockException.INVALID_BLOCK_ACCESS_LIST: (
+            r"InvalidBlockLevelAccessListRoot:"
+            r"|could not be parsed as a block: Could not decode block access list."
+        ),
+        BlockException.INCORRECT_BLOCK_FORMAT: (
+            r"could not be parsed as a block: Could not decode block access list."
+        ),
     }

--- a/packages/testing/src/execution_testing/client_clis/clis/reth.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/reth.py
@@ -74,4 +74,18 @@ class RethExceptionMapper(ExceptionMapper):
         BlockException.INVALID_GAS_USED_ABOVE_LIMIT: (
             r"block used gas \(\d+\) is greater than gas limit \(\d+\)"
         ),
+        # BAL Exceptions: TODO - review once all clients completed.
+        BlockException.INVALID_BAL_EXTRA_ACCOUNT: (
+            r"Block BAL contains an account change that is not present in the computed BAL."
+        ),
+        BlockException.INVALID_BAL_HASH: (r"Block's access list is invalid."),
+        BlockException.INVALID_BAL_MISSING_ACCOUNT: (
+            r"Block BAL is missing an account change that is present in the computed BAL."
+        ),
+        BlockException.INVALID_BLOCK_ACCESS_LIST: (
+            r"Block's access list is invalid."
+        ),
+        BlockException.INCORRECT_BLOCK_FORMAT: (
+            r"Block's access list is invalid."
+        ),
     }

--- a/packages/testing/src/execution_testing/client_clis/tests/test_transition_tools_support.py
+++ b/packages/testing/src/execution_testing/client_clis/tests/test_transition_tools_support.py
@@ -265,12 +265,12 @@ def test_t8n_support(fork: Fork, installed_t8n: TransitionTool) -> None:
 
     test = BlockchainTest(
         genesis_environment=env,
+        fork=fork,
         pre=pre,
         post=block_1.expected_post_state,
         blocks=[block_1, block_2],
     )
     test.generate(
         t8n=installed_t8n,
-        fork=fork,
         fixture_format=BlockchainFixture,
     )

--- a/packages/testing/src/execution_testing/specs/blobs.py
+++ b/packages/testing/src/execution_testing/specs/blobs.py
@@ -10,7 +10,6 @@ from execution_testing.fixtures import (
     BaseFixture,
     FixtureFormat,
 )
-from execution_testing.forks import Fork
 from execution_testing.test_types import (
     NetworkWrappedTransaction,
     Transaction,
@@ -38,22 +37,18 @@ class BlobsTest(BaseTest):
         self,
         *,
         t8n: TransitionTool,
-        fork: Fork,
         fixture_format: FixtureFormat,
     ) -> BaseFixture:
         """Generate the list of test fixtures."""
-        del t8n, fork
+        del t8n
         raise Exception(f"Unknown fixture format: {fixture_format}")
 
     def execute(
         self,
         *,
-        fork: Fork,
         execute_format: ExecuteFormat,
     ) -> BaseExecute:
         """Generate the list of test fixtures."""
-        del fork
-
         if execute_format == BlobTransaction:
             return BlobTransaction(
                 txs=self.txs,

--- a/packages/testing/src/execution_testing/specs/tests/test_benchmark.py
+++ b/packages/testing/src/execution_testing/specs/tests/test_benchmark.py
@@ -6,6 +6,7 @@ transaction splitting functionality.
 import pytest
 
 from execution_testing.base_types import HexNumber
+from execution_testing.forks import Osaka
 from execution_testing.specs.benchmark import BenchmarkTest
 from execution_testing.test_types import Alloc, Environment, Transaction
 
@@ -34,6 +35,7 @@ def test_split_transaction(
 
     # Create a minimal BenchmarkTest instance
     benchmark_test = BenchmarkTest(
+        fork=Osaka,
         pre=Alloc(),
         post=Alloc(),
         tx=Transaction(sender=HexNumber(0), to=HexNumber(0), nonce=0),
@@ -96,7 +98,9 @@ def test_split_transaction_edge_cases(
     gas_benchmark_value: int, gas_limit_cap: int | None
 ) -> None:
     """Test edge cases for transaction splitting."""
+    fork = Osaka
     benchmark_test = BenchmarkTest(
+        fork=fork,
         pre=Alloc(),
         post=Alloc(),
         tx=Transaction(

--- a/packages/testing/src/execution_testing/specs/tests/test_expect.py
+++ b/packages/testing/src/execution_testing/specs/tests/test_expect.py
@@ -70,13 +70,17 @@ def fork() -> Fork:  # noqa: D103
 
 @pytest.fixture
 def state_test(  # noqa: D103
-    pre: Mapping[Any, Any], post: Mapping[Any, Any], tx: Transaction
+    pre: Mapping[Any, Any],
+    post: Mapping[Any, Any],
+    tx: Transaction,
+    fork: Fork,
 ) -> StateTest:
     return StateTest(
         env=Environment(),
         pre=pre,
         post=post,
         tx=tx,
+        fork=fork,
     )
 
 
@@ -173,9 +177,7 @@ def test_post_storage_value_mismatch(
     generation.
     """
     with pytest.raises(Storage.KeyValueMismatchError) as e_info:
-        state_test.generate(
-            t8n=default_t8n, fork=fork, fixture_format=StateFixture
-        )
+        state_test.generate(t8n=default_t8n, fixture_format=StateFixture)
     assert e_info.value == expected_exception
 
 
@@ -216,14 +218,10 @@ def test_post_nonce_value_mismatch(
     pre_nonce = pre_account.nonce
     post_nonce = post_account.nonce
     if "nonce" not in post_account.model_fields_set:  # no exception
-        state_test.generate(
-            t8n=default_t8n, fork=fork, fixture_format=StateFixture
-        )
+        state_test.generate(t8n=default_t8n, fixture_format=StateFixture)
         return
     with pytest.raises(Account.NonceMismatchError) as e_info:
-        state_test.generate(
-            t8n=default_t8n, fork=fork, fixture_format=StateFixture
-        )
+        state_test.generate(t8n=default_t8n, fixture_format=StateFixture)
     assert e_info.value == Account.NonceMismatchError(
         address=ADDRESS_UNDER_TEST, want=post_nonce, got=pre_nonce
     )
@@ -266,14 +264,10 @@ def test_post_code_value_mismatch(
     pre_code = pre_account.code
     post_code = post_account.code
     if "code" not in post_account.model_fields_set:  # no exception
-        state_test.generate(
-            t8n=default_t8n, fork=fork, fixture_format=StateFixture
-        )
+        state_test.generate(t8n=default_t8n, fixture_format=StateFixture)
         return
     with pytest.raises(Account.CodeMismatchError) as e_info:
-        state_test.generate(
-            t8n=default_t8n, fork=fork, fixture_format=StateFixture
-        )
+        state_test.generate(t8n=default_t8n, fixture_format=StateFixture)
     assert e_info.value == Account.CodeMismatchError(
         address=ADDRESS_UNDER_TEST, want=post_code, got=pre_code
     )
@@ -316,14 +310,10 @@ def test_post_balance_value_mismatch(
     pre_balance = pre_account.balance
     post_balance = post_account.balance
     if "balance" not in post_account.model_fields_set:  # no exception
-        state_test.generate(
-            t8n=default_t8n, fork=fork, fixture_format=StateFixture
-        )
+        state_test.generate(t8n=default_t8n, fixture_format=StateFixture)
         return
     with pytest.raises(Account.BalanceMismatchError) as e_info:
-        state_test.generate(
-            t8n=default_t8n, fork=fork, fixture_format=StateFixture
-        )
+        state_test.generate(t8n=default_t8n, fixture_format=StateFixture)
     assert e_info.value == Account.BalanceMismatchError(
         address=ADDRESS_UNDER_TEST, want=post_balance, got=pre_balance
     )
@@ -370,14 +360,10 @@ def test_post_account_mismatch(
     fixture generation.
     """
     if exception_type is None:
-        state_test.generate(
-            t8n=default_t8n, fork=fork, fixture_format=StateFixture
-        )
+        state_test.generate(t8n=default_t8n, fixture_format=StateFixture)
         return
     with pytest.raises(exception_type) as _:
-        state_test.generate(
-            t8n=default_t8n, fork=fork, fixture_format=StateFixture
-        )
+        state_test.generate(t8n=default_t8n, fixture_format=StateFixture)
 
 
 # Transaction result mismatch tests
@@ -466,14 +452,10 @@ def test_transaction_expectation(
             f"({default_t8n.__class__.__name__})."
         )
     if exception_type is None:
-        state_test.generate(
-            t8n=default_t8n, fork=fork, fixture_format=fixture_format
-        )
+        state_test.generate(t8n=default_t8n, fixture_format=fixture_format)
     else:
         with pytest.raises(exception_type) as _:
-            state_test.generate(
-                t8n=default_t8n, fork=fork, fixture_format=fixture_format
-            )
+            state_test.generate(t8n=default_t8n, fixture_format=fixture_format)
 
 
 @pytest.mark.parametrize(
@@ -552,18 +534,18 @@ def test_block_intermediate_state(
     if expected_exception:
         with pytest.raises(expected_exception) as _:
             BlockchainTest(
+                fork=fork,
                 genesis_environment=env,
                 pre=pre,
                 post=block_3.expected_post_state,
                 blocks=[block_1, block_2, block_3],
-            ).generate(
-                t8n=default_t8n, fork=fork, fixture_format=fixture_format
-            )
+            ).generate(t8n=default_t8n, fixture_format=fixture_format)
         return
     else:
         BlockchainTest(
+            fork=fork,
             genesis_environment=env,
             pre=pre,
             post=block_3.expected_post_state,
             blocks=[block_1, block_2, block_3],
-        ).generate(t8n=default_t8n, fork=fork, fixture_format=fixture_format)
+        ).generate(t8n=default_t8n, fixture_format=fixture_format)

--- a/packages/testing/src/execution_testing/specs/tests/test_fixtures.py
+++ b/packages/testing/src/execution_testing/specs/tests/test_fixtures.py
@@ -109,12 +109,13 @@ def test_make_genesis(
     )
 
     fixture = BlockchainTest(
+        fork=fork,
         genesis_environment=env,
         pre=pre,
         post={},
         blocks=[],
         tag="some_state_test",
-    ).generate(t8n=default_t8n, fork=fork, fixture_format=BlockchainFixture)
+    ).generate(t8n=default_t8n, fixture_format=BlockchainFixture)
     assert isinstance(fixture, BlockchainFixture)
     assert fixture.genesis is not None
 
@@ -193,12 +194,13 @@ def test_fill_state_test(
     }
 
     generated_fixture = StateTest(
+        fork=fork,
         env=env,
         pre=pre,
         post=post,
         tx=tx,
         tag="my_chain_id_test",
-    ).generate(t8n=default_t8n, fork=fork, fixture_format=fixture_format)
+    ).generate(t8n=default_t8n, fixture_format=fixture_format)
     assert generated_fixture.__class__ == fixture_format
     fixture = {
         f"000/my_chain_id_test/{fork}/tx_type_{tx_type}": generated_fixture.json_dict_with_info(
@@ -521,12 +523,13 @@ class TestFillBlockchainValidTxs:
         default_t8n: TransitionTool,
     ) -> BaseFixture:
         return BlockchainTest(
+            fork=fork,
             pre=pre,
             post=post,
             blocks=blocks,
             genesis_environment=genesis_environment,
             tag="my_blockchain_test_valid_txs",
-        ).generate(t8n=default_t8n, fork=fork, fixture_format=fixture_format)
+        ).generate(t8n=default_t8n, fixture_format=fixture_format)
 
     @pytest.mark.parametrize("fork", [London, Shanghai], indirect=True)
     def test_fill_blockchain_valid_txs(  # noqa: D102
@@ -914,11 +917,12 @@ def test_fill_blockchain_invalid_txs(
         BlockchainEngineFixture if check_hive else BlockchainFixture
     )
     generated_fixture = BlockchainTest(
+        fork=fork,
         pre=pre,
         post=post,
         blocks=blocks,
         genesis_environment=genesis_environment,
-    ).generate(t8n=default_t8n, fork=fork, fixture_format=fixture_format)
+    ).generate(t8n=default_t8n, fixture_format=fixture_format)
     assert generated_fixture.__class__ == fixture_format
     # BlockchainEngineFixture inherits from BlockchainEngineFixtureCommon
     # (not BlockchainFixtureCommon)

--- a/packages/testing/src/execution_testing/specs/tests/test_transaction.py
+++ b/packages/testing/src/execution_testing/specs/tests/test_transaction.py
@@ -28,10 +28,10 @@ def test_transaction_test_filling(
 ) -> None:
     """Test the transaction test filling."""
     generated_fixture = TransactionTest(
-        tx=tx.with_signature_and_sender()
+        tx=tx.with_signature_and_sender(),
+        fork=fork,
     ).generate(
         t8n=None,  # type: ignore
-        fork=fork,
         fixture_format=TransactionFixture,
     )
     assert generated_fixture.__class__ == TransactionFixture

--- a/packages/testing/src/execution_testing/specs/transaction.py
+++ b/packages/testing/src/execution_testing/specs/transaction.py
@@ -16,7 +16,6 @@ from execution_testing.fixtures import (
     TransactionFixture,
 )
 from execution_testing.fixtures.transaction import FixtureResult
-from execution_testing.forks import Fork
 from execution_testing.test_types import Alloc, Transaction
 
 from .base import BaseTest
@@ -45,7 +44,6 @@ class TransactionTest(BaseTest):
 
     def make_transaction_test_fixture(
         self,
-        fork: Fork,
     ) -> TransactionFixture:
         """Create a fixture from the transaction test definition."""
         if self.tx.error is not None:
@@ -57,7 +55,7 @@ class TransactionTest(BaseTest):
             )
         else:
             intrinsic_gas_cost_calculator = (
-                fork.transaction_intrinsic_cost_calculator()
+                self.fork.transaction_intrinsic_cost_calculator()
             )
             intrinsic_gas = intrinsic_gas_cost_calculator(
                 calldata=self.tx.data,
@@ -74,7 +72,7 @@ class TransactionTest(BaseTest):
 
         return TransactionFixture(
             result={
-                fork: result,
+                self.fork: result,
             },
             transaction=self.tx.with_signature_and_sender().rlp(),
         )
@@ -82,7 +80,6 @@ class TransactionTest(BaseTest):
     def generate(
         self,
         t8n: TransitionTool,
-        fork: Fork,
         fixture_format: FixtureFormat,
     ) -> BaseFixture:
         """Generate the TransactionTest fixture."""
@@ -90,19 +87,16 @@ class TransactionTest(BaseTest):
 
         self.check_exception_test(exception=self.tx.error is not None)
         if fixture_format == TransactionFixture:
-            return self.make_transaction_test_fixture(fork)
+            return self.make_transaction_test_fixture()
 
         raise Exception(f"Unknown fixture format: {fixture_format}")
 
     def execute(
         self,
         *,
-        fork: Fork,
         execute_format: ExecuteFormat,
     ) -> BaseExecute:
         """Execute the transaction test by sending it to the live network."""
-        del fork
-
         if execute_format == TransactionPost:
             return TransactionPost(
                 blocks=[[self.tx]],

--- a/packages/testing/src/execution_testing/tools/tests/test_code.py
+++ b/packages/testing/src/execution_testing/tools/tests/test_code.py
@@ -690,13 +690,13 @@ def test_switch(
     }
     state_test = StateTest(
         env=Environment(),
+        fork=Cancun,
         pre=pre,
         tx=tx,
         post=post,
     )
     state_test.generate(
         t8n=default_t8n,
-        fork=Cancun,
         fixture_format=BlockchainFixture,
     )
 

--- a/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
@@ -110,11 +110,6 @@ class ForkLoad:
         return self._module("fork").state_transition
 
     @property
-    def pay_rewards(self) -> Any:
-        """pay_rewards function of the fork."""
-        return self._module("fork").pay_rewards
-
-    @property
     def signing_hash(self) -> Any:
         """signing_hash function of the fork."""
         return self._module("transactions").signing_hash
@@ -158,11 +153,6 @@ class ForkLoad:
     def process_transaction(self) -> Any:
         """process_transaction function of the fork."""
         return self._module("fork").process_transaction
-
-    @property
-    def MAX_BLOB_GAS_PER_BLOCK(self) -> Any:
-        """MAX_BLOB_GAS_PER_BLOCK parameter of the fork."""
-        return self._module("fork").MAX_BLOB_GAS_PER_BLOCK
 
     @property
     def Block(self) -> Any:
@@ -240,11 +230,6 @@ class ForkLoad:
         return self._module("blocks").Withdrawal
 
     @property
-    def encode_transaction(self) -> Any:
-        """encode_transaction function of the fork."""
-        return self._module("transactions").encode_transaction
-
-    @property
     def decode_transaction(self) -> Any:
         """decode_transaction function of the fork."""
         return self._module("transactions").decode_transaction
@@ -318,31 +303,6 @@ class ForkLoad:
     def Authorization(self) -> Any:
         """Authorization class of the fork."""
         return self._module("fork_types").Authorization
-
-    @property
-    def TARGET_BLOB_GAS_PER_BLOCK(self) -> Any:
-        """TARGET_BLOB_GAS_PER_BLOCK of the fork."""
-        return self._module("vm.gas").TARGET_BLOB_GAS_PER_BLOCK
-
-    @property
-    def GAS_PER_BLOB(self) -> Any:
-        """GAS_PER_BLOB of the fork."""
-        return self._module("vm.gas").GAS_PER_BLOB
-
-    @property
-    def BLOB_BASE_COST(self) -> Any:
-        """BLOB_BASE_COST of the fork."""
-        return self._module("vm.gas").BLOB_BASE_COST
-
-    @property
-    def BLOB_SCHEDULE_MAX(self) -> Any:
-        """BLOB_SCHEDULE_MAX of the fork."""
-        return self._module("vm.gas").BLOB_SCHEDULE_MAX
-
-    @property
-    def BLOB_SCHEDULE_TARGET(self) -> Any:
-        """BLOB_SCHEDULE_TARGET of the fork."""
-        return self._module("vm.gas").BLOB_SCHEDULE_TARGET
 
     @property
     def calculate_excess_blob_gas(self) -> Any:

--- a/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
@@ -345,6 +345,11 @@ class ForkLoad:
         return self._module("vm.gas").BLOB_SCHEDULE_TARGET
 
     @property
+    def calculate_excess_blob_gas(self) -> Any:
+        """calculate_excess_blob_gas of the fork."""
+        return self._module("vm.gas").calculate_excess_blob_gas
+
+    @property
     def calculate_blob_gas_price(self) -> Any:
         """calculate_blob_gas_price of the fork."""
         return self._module("vm.gas").calculate_blob_gas_price


### PR DESCRIPTION
## Add Hive Consume Tests CI Workflow

Testing workflow before merging to ethereum/execution-specs.

**Tests (run in parallel):**
- `ethereum/eels/consume-engine`
- `ethereum/eels/consume-rlp`
- `ethereum/eels/consume-sync`
- Dev mode test with `uv run consume engine`

**Configuration:**
- Uses go-ethereum via ethpandaops docker image
- Fixtures: `develop@latest`
- Quick validation with specific test keys
- Ubuntu runners for testing