### PR TITLE
chore(tests,test-*,doc): remove more eof

### DIFF
--- a/docs/dev/docs.md
+++ b/docs/dev/docs.md
@@ -113,7 +113,7 @@ uv run mike list
 Delete a version:
 
 ```console
-uv run mike delete v1.2.3a1-eof
+uv run mike delete v1.2.3a1
 ```
 
 ### Set Default Version

--- a/docs/writing_tests/fork_methods.md
+++ b/docs/writing_tests/fork_methods.md
@@ -124,10 +124,9 @@ fork.system_contracts(block_number=0, timestamp=0)  # Returns list of system con
 Methods for determining EVM features and valid opcodes:
 
 ```python
-fork.evm_code_types(block_number=0, timestamp=0)  # Returns list of supported code types (e.g., Legacy, EOF)
 fork.valid_opcodes()  # Returns list of valid opcodes for this fork
-fork.call_opcodes(block_number=0, timestamp=0)  # Returns list of call opcodes with their code types
-fork.create_opcodes(block_number=0, timestamp=0)  # Returns list of create opcodes with their code types
+fork.call_opcodes(block_number=0, timestamp=0)  # Returns list of call opcodes
+fork.create_opcodes(block_number=0, timestamp=0)  # Returns list of create opcodes
 ```
 
 ### Blob-related Methods (Cancun+)

--- a/docs/writing_tests/test_markers.md
+++ b/docs/writing_tests/test_markers.md
@@ -129,59 +129,6 @@ def test_something_with_all_precompiles(
 
 In this example, the test will be parameterized for parameter `precompile` with values `[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]` for fork Shanghai, but with values `[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]` for fork Cancun which introduced the [point evaluation precompile](https://eips.ethereum.org/EIPS/eip-4844#point-evaluation-precompile) defined in EIP-4844.
 
-### `@pytest.mark.with_all_evm_code_types`
-
-This marker is used to automatically parameterize a test with all EVM code types that are valid for the fork being tested.
-
-```python
-import pytest
-
-from execution_testing.tools import Alloc, StateTestFiller
-
-@pytest.mark.with_all_evm_code_types
-@pytest.mark.valid_from("Frontier")
-def test_something_with_all_evm_code_types(
-    state_test: StateTestFiller,
-    pre: Alloc,
-):
-    pass
-```
-
-In this example, the test will be parameterized for parameter `evm_code_type` only with value `[EVMCodeType.LEGACY]` starting on fork Frontier, and eventually it will be parametrized with with values `[EVMCodeType.LEGACY, EVMCodeType.EOF_V1]` on the EOF activation fork.
-
-In all calls to `pre.deploy_contract`, if the code parameter is `Bytecode` type, and `evm_code_type==EVMCodeType.EOF_V1`, the bytecode will be automatically wrapped in an EOF V1 container.
-
-Code wrapping might fail in the following circumstances:
-
-- The code contains invalid EOF V1 opcodes.
-- The code does not end with a valid EOF V1 terminating opcode (such as `Op.STOP` or `Op.REVERT` or `Op.RETURN`).
-
-In the case where the code wrapping fails, `evm_code_type` can be added as a parameter to the test and the bytecode can be dynamically modified to be compatible with the EOF V1 container.
-
-One thing to note is that `evm_code_type` is not necessary to be added as a parameter to the test because the `pre: Alloc` fixture automatically consumes this fixture, and therefore it only needs to be added to the test signature if the test's logic needs it.
-
-```python
-import pytest
-
-from execution_testing.tools import Alloc, StateTestFiller
-from execution_testing.vm import EVMCodeType
-from execution_testing.vm import Opcodes as Op
-
-@pytest.mark.with_all_evm_code_types
-@pytest.mark.valid_from("Frontier")
-def test_something_with_all_evm_code_types(
-    state_test: StateTestFiller,
-    pre: Alloc,
-    evm_code_type: EVMCodeType
-):
-    code = Op.SSTORE(1, 1)
-    if evm_code_type == EVMCodeType.EOF_V1:
-        # Modify the bytecode to be compatible with EOF V1 container
-        code += Op.STOP
-    pre.deploy_contract(code)
-    ...
-```
-
 ### `@pytest.mark.with_all_call_opcodes`
 
 This marker is used to automatically parameterize a test with all EVM call opcodes that are valid for the fork being tested.
@@ -202,9 +149,7 @@ def test_something_with_all_call_opcodes(
     pass
 ```
 
-In this example, the test will be parametrized for parameter `call_opcode` with values `[Op.CALL, Op.CALLCODE]` starting on fork Frontier, `[Op.CALL, Op.CALLCODE, Op.DELEGATECALL]` on fork Homestead, `[Op.CALL, Op.CALLCODE, Op.DELEGATECALL, Op.STATICCALL]` on fork Byzantium, and eventually it will be parametrized with with values `[Op.CALL, Op.CALLCODE, Op.DELEGATECALL, Op.STATICCALL, Op.EXTCALL, Op.EXTSTATICCALL, Op.EXTDELEGATECALL]` on the EOF activation fork.
-
-Parameter `evm_code_type` will also be parametrized with the correct EVM code type for the opcode under test.
+In this example, the test will be parametrized for parameter `call_opcode` with values `[Op.CALL, Op.CALLCODE]` starting on fork Frontier, `[Op.CALL, Op.CALLCODE, Op.DELEGATECALL]` on fork Homestead, and `[Op.CALL, Op.CALLCODE, Op.DELEGATECALL, Op.STATICCALL]` on fork Byzantium and later.
 
 ### `@pytest.mark.with_all_create_opcodes`
 
@@ -226,9 +171,7 @@ def test_something_with_all_create_opcodes(
     pass
 ```
 
-In this example, the test will be parametrized for parameter `create_opcode` with values `[Op.CREATE]` starting on fork Frontier, `[Op.CREATE, Op.CREATE2]` starting on fork Constantinople, and eventually it will be parametrized with with values `[Op.CREATE, Op.CREATE2, Op.EOFCREATE]` on the EOF activation fork.
-
-Parameter `evm_code_type` will also be parametrized with the correct EVM code type for the opcode under test.
+In this example, the test will be parametrized for parameter `create_opcode` with values `[Op.CREATE]` starting on fork Frontier, and `[Op.CREATE, Op.CREATE2]` starting on fork Constantinople and later.
 
 ### `@pytest.mark.with_all_system_contracts`
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
@@ -414,25 +414,18 @@ fork_covariant_decorators: List[Type[CovariantDecorator]] = [
         argnames=["precompile"],
     ),
     covariant_decorator(
-        marker_name="with_all_evm_code_types",
-        description="marks a test to be parametrized for all EVM code types at parameter named"
-        " `evm_code_type` of type `EVMCodeType`, such as `LEGACY`",
-        fork_attribute_name="evm_code_types",
-        argnames=["evm_code_type"],
-    ),
-    covariant_decorator(
         marker_name="with_all_call_opcodes",
         description="marks a test to be parametrized for all *CALL opcodes at parameter named"
-        " call_opcode, and also the appropriate EVM code type at parameter named evm_code_type",
+        " call_opcode",
         fork_attribute_name="call_opcodes",
-        argnames=["call_opcode", "evm_code_type"],
+        argnames=["call_opcode"],
     ),
     covariant_decorator(
         marker_name="with_all_create_opcodes",
         description="marks a test to be parametrized for all *CREATE* opcodes at parameter named"
-        " create_opcode, and also the appropriate EVM code type at parameter named evm_code_type",
+        " create_opcode",
         fork_attribute_name="create_opcodes",
-        argnames=["create_opcode", "evm_code_type"],
+        argnames=["create_opcode"],
     ),
     covariant_decorator(
         marker_name="with_all_system_contracts",

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_covariant_markers.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_covariant_markers.py
@@ -171,20 +171,6 @@ import pytest
         pytest.param(
             """
             import pytest
-            @pytest.mark.with_all_evm_code_types()
-            @pytest.mark.valid_from("Cancun")
-            @pytest.mark.valid_until("Cancun")
-            @pytest.mark.state_test_only
-            def test_case(state_test, evm_code_type):
-                pass
-            """,
-            {"passed": 1, "failed": 0, "skipped": 0, "errors": 0},
-            None,
-            id="with_all_evm_code_types",
-        ),
-        pytest.param(
-            """
-            import pytest
             @pytest.mark.with_all_call_opcodes()
             @pytest.mark.valid_from("Cancun")
             @pytest.mark.valid_until("Cancun")
@@ -195,23 +181,6 @@ import pytest
             {"passed": 4, "failed": 0, "skipped": 0, "errors": 0},
             None,
             id="with_all_call_opcodes",
-        ),
-        pytest.param(
-            """
-            import pytest
-            from execution_testing import  EVMCodeType
-            @pytest.mark.with_all_call_opcodes(
-                selector=(lambda _, evm_code_type: evm_code_type == EVMCodeType.LEGACY)
-            )
-            @pytest.mark.valid_from("Cancun")
-            @pytest.mark.valid_until("Cancun")
-            @pytest.mark.state_test_only
-            def test_case(state_test, call_opcode):
-                pass
-            """,
-            {"passed": 4, "failed": 0, "skipped": 0, "errors": 0},
-            None,
-            id="with_all_call_opcodes_with_selector_for_evm_code_type",
         ),
         pytest.param(
             """

--- a/packages/testing/src/execution_testing/forks/base_fork.py
+++ b/packages/testing/src/execution_testing/forks/base_fork.py
@@ -12,7 +12,6 @@ from typing import (
     Protocol,
     Set,
     Sized,
-    Tuple,
     Type,
     Union,
 )
@@ -23,7 +22,7 @@ from execution_testing.base_types import (
     BlobSchedule,
 )
 from execution_testing.base_types.conversions import BytesConvertible
-from execution_testing.vm import EVMCodeType, Opcodes
+from execution_testing.vm import Opcodes
 
 from .base_decorators import prefer_transition_to_method
 from .gas_costs import GasCosts
@@ -779,14 +778,6 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
     # EVM information abstract methods
     @classmethod
     @abstractmethod
-    def evm_code_types(
-        cls, *, block_number: int = 0, timestamp: int = 0
-    ) -> List[EVMCodeType]:
-        """Return list of EVM code types supported by the fork."""
-        pass
-
-    @classmethod
-    @abstractmethod
     def max_code_size(
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> int:
@@ -819,11 +810,8 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
     @abstractmethod
     def call_opcodes(
         cls, *, block_number: int = 0, timestamp: int = 0
-    ) -> List[Tuple[Opcodes, EVMCodeType]]:
-        """
-        Return list of tuples with the call opcodes and its corresponding EVM
-        code type.
-        """
+    ) -> List[Opcodes]:
+        """Return list of call opcodes supported by the fork."""
         pass
 
     @classmethod
@@ -838,11 +826,8 @@ class BaseFork(ABC, metaclass=BaseForkMeta):
     @abstractmethod
     def create_opcodes(
         cls, *, block_number: int = 0, timestamp: int = 0
-    ) -> List[Tuple[Opcodes, EVMCodeType]]:
-        """
-        Return list of tuples with the create opcodes and its corresponding EVM
-        code type.
-        """
+    ) -> List[Opcodes]:
+        """Return list of create opcodes supported by the fork."""
         pass
 
     @classmethod

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -4,7 +4,7 @@ from dataclasses import replace
 from hashlib import sha256
 from os.path import realpath
 from pathlib import Path
-from typing import List, Literal, Mapping, Optional, Sized, Tuple
+from typing import List, Literal, Mapping, Optional, Sized
 
 from execution_testing.base_types import (
     AccessList,
@@ -14,7 +14,7 @@ from execution_testing.base_types import (
     ForkBlobSchedule,
 )
 from execution_testing.base_types.conversions import BytesConvertible
-from execution_testing.vm import EVMCodeType, Opcodes
+from execution_testing.vm import Opcodes
 
 from ..base_fork import (
     BaseFeeChangeCalculator,
@@ -609,14 +609,6 @@ class Frontier(BaseFork, solc_name="homestead"):
         return None
 
     @classmethod
-    def evm_code_types(
-        cls, *, block_number: int = 0, timestamp: int = 0
-    ) -> List[EVMCodeType]:
-        """At Genesis, only legacy EVM code is supported."""
-        del block_number, timestamp
-        return [EVMCodeType.LEGACY]
-
-    @classmethod
     def max_code_size(
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> int:
@@ -652,13 +644,10 @@ class Frontier(BaseFork, solc_name="homestead"):
     @classmethod
     def call_opcodes(
         cls, *, block_number: int = 0, timestamp: int = 0
-    ) -> List[Tuple[Opcodes, EVMCodeType]]:
+    ) -> List[Opcodes]:
         """Return list of call opcodes supported by the fork."""
         del block_number, timestamp
-        return [
-            (Opcodes.CALL, EVMCodeType.LEGACY),
-            (Opcodes.CALLCODE, EVMCodeType.LEGACY),
-        ]
+        return [Opcodes.CALL, Opcodes.CALLCODE]
 
     @classmethod
     def valid_opcodes(
@@ -801,12 +790,10 @@ class Frontier(BaseFork, solc_name="homestead"):
     @classmethod
     def create_opcodes(
         cls, *, block_number: int = 0, timestamp: int = 0
-    ) -> List[Tuple[Opcodes, EVMCodeType]]:
+    ) -> List[Opcodes]:
         """At Genesis, only `CREATE` opcode is supported."""
         del block_number, timestamp
-        return [
-            (Opcodes.CREATE, EVMCodeType.LEGACY),
-        ]
+        return [Opcodes.CREATE]
 
     @classmethod
     def max_refund_quotient(
@@ -872,11 +859,11 @@ class Homestead(Frontier):
     @classmethod
     def call_opcodes(
         cls, *, block_number: int = 0, timestamp: int = 0
-    ) -> List[Tuple[Opcodes, EVMCodeType]]:
+    ) -> List[Opcodes]:
         """At Homestead, DELEGATECALL opcode was introduced."""
-        return [(Opcodes.DELEGATECALL, EVMCodeType.LEGACY)] + super(
-            Homestead, cls
-        ).call_opcodes(block_number=block_number, timestamp=timestamp)
+        return [Opcodes.DELEGATECALL] + super(Homestead, cls).call_opcodes(
+            block_number=block_number, timestamp=timestamp
+        )
 
     @classmethod
     def valid_opcodes(
@@ -988,11 +975,11 @@ class Byzantium(Homestead):
     @classmethod
     def call_opcodes(
         cls, *, block_number: int = 0, timestamp: int = 0
-    ) -> List[Tuple[Opcodes, EVMCodeType]]:
+    ) -> List[Opcodes]:
         """At Byzantium, STATICCALL opcode was introduced."""
-        return [(Opcodes.STATICCALL, EVMCodeType.LEGACY)] + super(
-            Byzantium, cls
-        ).call_opcodes(block_number=block_number, timestamp=timestamp)
+        return [Opcodes.STATICCALL] + super(Byzantium, cls).call_opcodes(
+            block_number=block_number, timestamp=timestamp
+        )
 
     @classmethod
     def valid_opcodes(
@@ -1040,11 +1027,11 @@ class Constantinople(Byzantium):
     @classmethod
     def create_opcodes(
         cls, *, block_number: int = 0, timestamp: int = 0
-    ) -> List[Tuple[Opcodes, EVMCodeType]]:
+    ) -> List[Opcodes]:
         """At Constantinople, `CREATE2` opcode is added."""
-        return [(Opcodes.CREATE2, EVMCodeType.LEGACY)] + super(
-            Constantinople, cls
-        ).create_opcodes(block_number=block_number, timestamp=timestamp)
+        return [Opcodes.CREATE2] + super(Constantinople, cls).create_opcodes(
+            block_number=block_number, timestamp=timestamp
+        )
 
     @classmethod
     def valid_opcodes(

--- a/packages/testing/src/execution_testing/tools/tools_code/generators.py
+++ b/packages/testing/src/execution_testing/tools/tools_code/generators.py
@@ -7,7 +7,7 @@ from typing_extensions import Self
 
 from execution_testing.base_types import Bytes
 from execution_testing.test_types import ceiling_division
-from execution_testing.vm import Bytecode, EVMCodeType, Op
+from execution_testing.vm import Bytecode, Op
 
 GAS_PER_DEPLOYED_CODE_BYTE = 0xC8
 
@@ -200,7 +200,6 @@ class Conditional(Bytecode):
         condition: Bytecode | Op,
         if_true: Bytecode | Op | None = None,
         if_false: Bytecode | Op | None = None,
-        evm_code_type: EVMCodeType = EVMCodeType.LEGACY,
     ) -> Self:
         """
         Assemble the conditional bytecode by generating the necessary jump and
@@ -240,7 +239,6 @@ class While(Bytecode):
         *,
         body: Bytecode | Op,
         condition: Bytecode | Op | None = None,
-        evm_code_type: EVMCodeType = EVMCodeType.LEGACY,
     ) -> Self:
         """
         Assemble the loop bytecode.
@@ -328,17 +326,11 @@ class Switch(Bytecode):
     evaluates to a non-zero value is the one that is executed.
     """
 
-    evm_code_type: EVMCodeType
-    """
-    The EVM code type to use for the switch-case bytecode.
-    """
-
     def __new__(
         cls,
         *,
         default_action: Bytecode | Op | None = None,
         cases: List[Case],
-        evm_code_type: EVMCodeType = EVMCodeType.LEGACY,
     ) -> Self:
         """
         Assemble the bytecode by looping over the list of cases and adding the

--- a/packages/testing/src/execution_testing/vm/helpers.py
+++ b/packages/testing/src/execution_testing/vm/helpers.py
@@ -93,9 +93,7 @@ class MemoryVariable(Bytecode):
         return Op.RETURN(offset=self.offset, size=32)
 
 
-def call_return_code(
-    opcode: Op, success: bool, *, revert: bool = False
-) -> int:
+def call_return_code(opcode: Op, success: bool) -> int:
     """Return return code for a CALL operation."""
     if opcode in [Op.CALL, Op.CALLCODE, Op.DELEGATECALL, Op.STATICCALL]:
         return int(success)

--- a/tests/frontier/scenarios/scenarios/call_combinations.py
+++ b/tests/frontier/scenarios/scenarios/call_combinations.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from typing import List
 
-from execution_testing import Address, Alloc, EVMCodeType, Op, Opcode
+from execution_testing import Address, Alloc, Op, Opcode
 
 from ..common import Scenario, ScenarioEnvironment, ScenarioGeneratorInput
 
@@ -41,11 +41,7 @@ class ScenariosCallCombinations:
 
     def __init__(self, scenario_input: ScenarioGeneratorInput):
         """Define possible call combinations given the fork."""
-        self.first_call_opcodes = [
-            callcode
-            for callcode, evm_type in scenario_input.fork.call_opcodes()
-            if evm_type == EVMCodeType.LEGACY
-        ]
+        self.first_call_opcodes = list(scenario_input.fork.call_opcodes())
         self.second_call_opcodes = self.first_call_opcodes[:]
         self.second_call_opcodes.append(Op.NOOP)
         self.scenario_input = scenario_input

--- a/tests/frontier/scenarios/scenarios/create_combinations.py
+++ b/tests/frontier/scenarios/scenarios/create_combinations.py
@@ -6,7 +6,6 @@ from typing import List
 from execution_testing import (
     Alloc,
     Bytecode,
-    EVMCodeType,
     Op,
     Opcode,
     compute_create_address,
@@ -49,11 +48,7 @@ def scenarios_create_combinations(
 
     scenarios_list: List[Scenario] = []
     keep_gas = 100000
-    create_types: List[Opcode] = [
-        create_code
-        for create_code, evm_type in scenario_input.fork.create_opcodes()
-        if evm_type == EVMCodeType.LEGACY
-    ]
+    create_types: List[Opcode] = list(scenario_input.fork.create_opcodes())
     env: ScenarioEnvironment
     balance: AddressBalance = AddressBalance()
 
@@ -111,11 +106,7 @@ def scenarios_create_combinations(
         + Op.RETURN(0, Op.EXTCODESIZE(operation_contract))
     )
     deploy_code_size: int = int(len(deploy_code.hex()) / 2)
-    call_types: List[Opcode] = [
-        callcode
-        for callcode, evm_type in scenario_input.fork.call_opcodes()
-        if evm_type == EVMCodeType.LEGACY
-    ]
+    call_types: List[Opcode] = list(scenario_input.fork.call_opcodes())
 
     pre: Alloc = scenario_input.pre
     for create in create_types:

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -371,7 +371,6 @@ def test_set_code_to_tstore_reentry(
     pre: Alloc,
     call_opcode: Op,
     return_opcode: Op,
-    evm_code_type: EVMCodeType,
 ) -> None:
     """
     Test the executing a simple TSTORE in a set-code transaction, which also
@@ -387,7 +386,6 @@ def test_set_code_to_tstore_reentry(
         + Op.RETURNDATACOPY(0, 0, 32)
         + Op.SSTORE(2, Op.MLOAD(0)),
         if_false=Op.MSTORE(0, Op.TLOAD(1)) + return_opcode(size=32),
-        evm_code_type=evm_code_type,
     )
     set_code_to_address = pre.deploy_contract(set_code)
 
@@ -717,7 +715,6 @@ def test_set_code_to_contract_creator(
     state_test: StateTestFiller,
     pre: Alloc,
     create_opcode: Op,
-    evm_code_type: EVMCodeType,
 ) -> None:
     """
     Test the executing a contract-creating opcode in a set-code transaction.
@@ -726,12 +723,7 @@ def test_set_code_to_contract_creator(
     auth_signer = pre.fund_eoa(auth_account_start_balance)
 
     deployed_code: Bytecode = Op.STOP
-    initcode: Bytecode
-
-    if evm_code_type == EVMCodeType.LEGACY:
-        initcode = Initcode(deploy_code=deployed_code)
-    else:
-        raise ValueError(f"Unsupported EVM code type: {evm_code_type}")
+    initcode: Bytecode = Initcode(deploy_code=deployed_code)
 
     deployed_contract_address = compute_create_address(
         address=auth_signer,
@@ -740,14 +732,12 @@ def test_set_code_to_contract_creator(
         opcode=create_opcode,
     )
 
-    creator_code: Bytecode
-    if evm_code_type == EVMCodeType.LEGACY:
-        creator_code = Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE) + Op.SSTORE(
-            storage.store_next(deployed_contract_address),
-            create_opcode(value=0, offset=0, size=Op.CALLDATASIZE),
-        )
-    else:
-        raise ValueError(f"Unsupported EVM code type: {evm_code_type}")
+    creator_code: Bytecode = Op.CALLDATACOPY(
+        0, 0, Op.CALLDATASIZE
+    ) + Op.SSTORE(
+        storage.store_next(deployed_contract_address),
+        create_opcode(value=0, offset=0, size=Op.CALLDATASIZE),
+    )
 
     creator_code_address = pre.deploy_contract(creator_code)
 
@@ -755,7 +745,7 @@ def test_set_code_to_contract_creator(
         gas_limit=10_000_000,
         to=auth_signer,
         value=0,
-        data=initcode if evm_code_type == EVMCodeType.LEGACY else b"",
+        data=initcode,
         authorization_list=[
             AuthorizationTuple(
                 address=creator_code_address,
@@ -795,7 +785,6 @@ def test_set_code_to_self_caller(
     pre: Alloc,
     call_opcode: Op,
     value: int,
-    evm_code_type: EVMCodeType,
 ) -> None:
     """Test the executing a self-call in a set-code transaction."""
     if "value" not in call_opcode.kwargs and value != 0:
@@ -821,7 +810,6 @@ def test_set_code_to_self_caller(
         + Op.SSTORE(re_entry_call_return_code_slot, call_bytecode)
         + Op.STOP,
         if_false=Op.SSTORE(re_entry_success_slot, 1) + Op.STOP,
-        evm_code_type=evm_code_type,
     )
     set_code_to_address = pre.deploy_contract(set_code)
 
@@ -1412,7 +1400,6 @@ def test_ext_code_on_self_set_code(
     )
 
 
-@pytest.mark.with_all_evm_code_types()
 @pytest.mark.parametrize(
     "set_code_address_first",
     [
@@ -1823,7 +1810,6 @@ def test_set_code_to_account_deployed_in_same_tx(
     state_test: StateTestFiller,
     pre: Alloc,
     create_opcode: Op,
-    evm_code_type: EVMCodeType,
 ) -> None:
     """
     Test setting the code of an account to an address that is deployed in the
@@ -1835,12 +1821,7 @@ def test_set_code_to_account_deployed_in_same_tx(
     success_slot = 1
 
     deployed_code: Bytecode = Op.SSTORE(success_slot, 1) + Op.STOP
-    initcode: Bytecode
-
-    if evm_code_type == EVMCodeType.LEGACY:
-        initcode = Initcode(deploy_code=deployed_code)
-    else:
-        raise ValueError(f"Unsupported EVM code type: {evm_code_type}")
+    initcode: Bytecode = Initcode(deploy_code=deployed_code)
 
     deployed_contract_address_slot = 1
     signer_call_return_code_slot = 2
@@ -1878,7 +1859,7 @@ def test_set_code_to_account_deployed_in_same_tx(
         gas_limit=10_000_000,
         to=contract_creator_address,
         value=0,
-        data=initcode if evm_code_type == EVMCodeType.LEGACY else b"",
+        data=initcode,
         authorization_list=[
             AuthorizationTuple(
                 address=deployed_contract_address,
@@ -2803,7 +2784,6 @@ def test_nonce_overflow_after_first_authorization(
         Op.LOG4,
     ],
 )
-@pytest.mark.with_all_evm_code_types
 def test_set_code_to_log(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -3152,7 +3132,6 @@ def test_set_code_to_system_contract(
     )
 
 
-@pytest.mark.with_all_evm_code_types
 @pytest.mark.with_all_tx_types(
     selector=lambda tx_type: tx_type != 4,
     marks=lambda tx_type: pytest.mark.execute(
@@ -3181,7 +3160,6 @@ def test_eoa_tx_after_set_code(
     pre: Alloc,
     tx_type: int,
     fork: Fork,
-    evm_code_type: EVMCodeType,
     same_block: bool,
 ) -> None:
     """


### PR DESCRIPTION
## 🗒️ Description

Additional suggested cleanup to #1873:
- Fixes unused arg errors (not caught by CI we have no ruff at the mo on packages/testing).
- Removes redundant EOF marker infrastructure, this cleans up test parameter IDs.

I filled the changed tests, and diff'd them with hasher - all good! Only clean test IDs that don't refer to the current EVM as "legacy", e.g.,:
```
 `tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_eoa_tx_after_set_code[fork_Osaka-tx_type_0-evm_code_type_LEGACY-blockchain_test-different_block]
  ->   
  `tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_eoa_tx_after_set_code[fork_Osaka-tx_type_0-blockchain_test-different_block]`  
``` 

## Changes

- Remove unused `revert` parameter from `call_return_code()` in `helpers.py`.
- Remove unused `evm_code_type` parameter from `Conditional`, `While`, and `Switch` in `generators.py`.
- Remove `with_all_evm_code_types` marker entirely.
- Remove `evm_code_types()` abstract method and implementations from fork classes.
- Simplify `call_opcodes()` and `create_opcodes()` to return `List[Opcodes]` instead of `List[Tuple[Opcodes, EVMCodeType]]`.
- Remove `evm_code_type` from `with_all_call_opcodes` and `with_all_create_opcodes` marker argnames.
- Update tests to remove unused `evm_code_type` parameters.
- Update documentation to remove EOF references.
  
## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Parent:
- ethereum/execution-specs#1873

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.

#### Cute Animal Picture

<img width="640" height="640" alt="image" src="https://github.com/user-attachments/assets/a327455e-d6bf-4ba0-9867-e837fbc7f9ff" />

