### PR TITLE
feat(github): add devnet tracker issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/devnet-tracker.md
+++ b/.github/ISSUE_TEMPLATE/devnet-tracker.md
@@ -37,12 +37,14 @@ assignees: ''
 > Aim to cut the test (fixture) release **at least 5 days before** the devnet
 > launch, to give client teams time to integrate and run them.
 
-### Follows On From
+### Follows On From _(optional)_
 
 <!--
-    If this is a follow-up release (most updates are test additions and the
-    scope is semantically unchanged), link the previous tracker and keep this
-    issue small — list only what is new below. Otherwise write "N/A".
+    Optional. If there is a previous devnet release tracker, link it here for
+    context — even if the scope has changed. If this is a test-only follow-up
+    (most updates are test additions and the scope is semantically unchanged),
+    keep this issue small and list only what is new below. If there is no
+    predecessor (a brand new `<feat>` / first devnet), remove this section.
 -->
 
 This is a follow-up to the `tests-<feat>-devnet@vX.Y.Z` tracker (#`<issue>`),

--- a/.github/ISSUE_TEMPLATE/devnet-tracker.md
+++ b/.github/ISSUE_TEMPLATE/devnet-tracker.md
@@ -1,6 +1,6 @@
 ---
 name: Devnet Tracker
-about: Track test release readiness for a devnet (tests-<feat>-devnet@vX.Y.Z)
+about: Track EL test release readiness for a devnet (tests-<feat>-devnet@vX.Y.Z)
 title: 'tests-<feat>-devnet@vX.Y.Z Tracker'
 labels: C-tracker, P-high
 assignees: ''
@@ -8,6 +8,10 @@ assignees: ''
 ---
 
 ## tests-`<feat>`-devnet@v`X.Y.Z`
+
+> [!NOTE]
+> This is an **execution layer (EL) only** tracker — it does not cover
+> consensus layer (CL) readiness.
 
 ### Overview
 

--- a/.github/ISSUE_TEMPLATE/devnet-tracker.md
+++ b/.github/ISSUE_TEMPLATE/devnet-tracker.md
@@ -21,8 +21,8 @@ assignees: ''
     against regressions, and is run in Hive CI under the standard naming scheme.
 -->
 
-- **Release tag**: <!-- e.g. tests-glamsterdam-devnet@v5.0.0 -->
-- **Specs**: <!-- link to the `feat-devnet-N` branch being used for this devnet -->
+- **Target release tag**: <!-- e.g. tests-glamsterdam-devnet@v5.0.0 -->
+- **EELS branch**: <!-- link to the `feat-devnet-N` branch being used for this devnet -->
 - **Test release date**: <!-- YYYY-MM-DD or "TBD" — aim for 5 days before the devnet -->
 - **Devnet launch date**: <!-- YYYY-MM-DD or "TBD" -->
 

--- a/.github/ISSUE_TEMPLATE/devnet-tracker.md
+++ b/.github/ISSUE_TEMPLATE/devnet-tracker.md
@@ -124,16 +124,17 @@ release here.
 ### Client Readiness
 
 <!--
-    Track which client implementations are ready for the devnet.
+    Track which client implementations are ready for the devnet. Link each
+    client's devnet branch / PR in the parentheses.
 -->
 
-- [ ] geth
-- [ ] erigon
-- [ ] besu
-- [ ] nethermind
-- [ ] reth
-- [ ] ethrex
-- [ ] nimbus-el
+- [ ] [geth]()
+- [ ] [erigon]()
+- [ ] [besu]()
+- [ ] [nethermind]()
+- [ ] [reth]()
+- [ ] [ethrex]()
+- [ ] [nimbus-el]()
 
 ### Process Status
 

--- a/.github/ISSUE_TEMPLATE/devnet-tracker.md
+++ b/.github/ISSUE_TEMPLATE/devnet-tracker.md
@@ -129,6 +129,7 @@ release here.
 - [ ] nethermind
 - [ ] reth
 - [ ] ethrex
+- [ ] nimbus-el
 
 ### Process Status
 

--- a/.github/ISSUE_TEMPLATE/devnet-tracker.md
+++ b/.github/ISSUE_TEMPLATE/devnet-tracker.md
@@ -1,41 +1,65 @@
 ---
 name: Devnet Tracker
-about: Track specification, testing, and launch readiness for a devnet
-title: '<devnet-name> Tracker'
+about: Track test release readiness for a devnet (tests-<feat>-devnet@vX.Y.Z)
+title: 'tests-<feat>-devnet@vX.Y.Z Tracker'
 labels: C-tracker, P-high
 assignees: ''
 
 ---
 
-## <devnet-name>
+## tests-`<feat>`-devnet@v`X.Y.Z`
 
 ### Overview
 
 <!--
-    Briefly describe the purpose of this devnet, its scope, and any relevant
-    links (devnet specs repo, ACD notes, configuration / genesis).
+    Briefly describe the purpose of this devnet test release, its scope, and any
+    relevant links (devnet specs repo, ACD notes, configuration / genesis).
+
+    The `<feat>` keyword is typically the fork name or headliner feature
+    (e.g. `bal`, `glamsterdam`). The release fills all forks until the
+    development fork (e.g. `fill --until Amsterdam`) so clients can guard
+    against regressions, and is run in Hive CI under the standard naming scheme.
 -->
 
-- **Specs**: <!-- link to the devnet specs / config repo -->
-- **Target release**: <!-- e.g. v7.3.0 or "TBD" -->
+- **Release tag**: <!-- e.g. tests-glamsterdam-devnet@v5.0.0 -->
+- **Specs**: <!-- link to the `feat-devnet-N` branch being used for this devnet -->
 - **Test release date**: <!-- YYYY-MM-DD or "TBD" — aim for 5 days before the devnet -->
 - **Devnet launch date**: <!-- YYYY-MM-DD or "TBD" -->
+
+> [!NOTE]
+> **Versioning** (`vX.Y.Z`): `X` is the devnet number (e.g. `5` for
+> `glamsterdam-devnet-5`), making the targeted devnet explicit. `Y`/`Z` follow
+> the same semantics as the consensus test releases.
 
 > [!NOTE]
 > Aim to cut the test (fixture) release **at least 5 days before** the devnet
 > launch, to give client teams time to integrate and run them.
 
+### Follows On From
+
+<!--
+    If this is a follow-up release (most updates are test additions and the
+    scope is semantically unchanged), link the previous tracker and keep this
+    issue small — list only what is new below. Otherwise write "N/A".
+-->
+
+This is a follow-up to the `tests-<feat>-devnet@vX.Y.Z` tracker (#`<issue>`),
+with test additions only.
+
+> [!TIP]
+> For a test-only follow-up, the sections below can be trimmed to just what
+> changed since the previous tracker.
+
 ### Aim
 
 <!--
-    A short statement of what we're aiming for in this devnet release.
+    A short statement of what we're aiming for in this devnet test release.
     Be explicit that the scope is tentative and will change.
 -->
 
-We aim to include the following EIPs in the first `<devnet-name>` EELS release
-(`v7.3.0`, following the previous `v7.2.0` release). This scope is tentative —
-EIPs may be added, dropped, or deferred as decisions land in ACD and during
-implementation.
+We aim to include the following EIPs in the first `<feat>-devnet-N` EELS test
+release (`tests-<feat>-devnet@vX.Y.Z`). This scope is tentative — EIPs may be
+added, dropped, or deferred as decisions land in ACD and during implementation.
 
 ### Instructions
 
@@ -85,11 +109,13 @@ release here.
 ### Specification + Testing Status
 
 - [ ] All included EIP specifications merged to the corresponding `feat-devnet-N` branch.
-- [ ] Devnet branch (`feat-devnet-N`) created and rebased on the target fork.
+- [ ] Devnet branch (`feat-devnet-N`) created and rebased on the target `forks/<fork>` branch.
 - [ ] Required testing framework modifications implemented.
 - [ ] Test suites for all included EIPs implemented.
 - [ ] No regressions or failures in tests from prior forks (including static tests).
 - [ ] Fixtures generated and released for the devnet.
+- [ ] [`hive-tests`](https://github.com/ethpandaops/hive-tests/tree/master/.github/workflows) repo checked/updated to run the latest set of fixtures.
+- [ ] [`hive-ui`](https://github.com/ethpandaops/hive-ui/blob/master/public/discovery.json) discovery checked/updated to the latest devnet workflow file within the `hive-tests` repo.
 
 ### Client Readiness
 
@@ -110,3 +136,16 @@ release here.
 - [ ] Interop / cross-client testing completed.
 - [ ] Devnet launched.
 - [ ] Post-launch issues triaged and tracked.
+
+### Closure
+
+<!--
+    Before closing this issue, link the test fixture release tag that shipped
+    for this devnet.
+-->
+
+- [ ] Linked the test fixture release tag used for this devnet: <!-- e.g. https://github.com/ethereum/execution-spec-tests/releases/tag/<tag> -->
+
+> [!IMPORTANT]
+> After tagging, any future changes must be added to a newly created devnet
+> tracker rather than reopening or amending this one.

--- a/.github/ISSUE_TEMPLATE/devnet-tracker.md
+++ b/.github/ISSUE_TEMPLATE/devnet-tracker.md
@@ -2,16 +2,12 @@
 name: Devnet Tracker
 about: Track specification, testing, and launch readiness for a devnet
 title: '<devnet-name> Tracker'
-labels: A-spec-specs, A-spec-tests, C-eip, C-test
+labels: C-tracker, P-high
 assignees: ''
 
 ---
 
 ## <devnet-name>
-
-### Target Fork
-
-**<fork>**
 
 ### Overview
 

--- a/.github/ISSUE_TEMPLATE/devnet-tracker.md
+++ b/.github/ISSUE_TEMPLATE/devnet-tracker.md
@@ -29,7 +29,9 @@ assignees: ''
 > [!NOTE]
 > **Versioning** (`vX.Y.Z`): `X` is the devnet number (e.g. `5` for
 > `glamsterdam-devnet-5`), making the targeted devnet explicit. `Y`/`Z` follow
-> the same semantics as the consensus test releases.
+> the same semantics as the consensus test releases: `Y` (minor) is bumped for
+> new or changed tests that add/modify fixtures, and `Z` (patch) is bumped for
+> backward-compatible fixes that do not change existing fixtures.
 
 > [!NOTE]
 > Aim to cut the test (fixture) release **at least 5 days before** the devnet

--- a/.github/ISSUE_TEMPLATE/devnet-tracker.md
+++ b/.github/ISSUE_TEMPLATE/devnet-tracker.md
@@ -32,9 +32,10 @@ assignees: ''
     Be explicit that the scope is tentative and will change.
 -->
 
-We aim to include the following EIPs in the first `<devnet-name>` EELS release.
-This scope is tentative — EIPs may be added, dropped, or deferred as decisions
-land in ACD and during implementation.
+We aim to include the following EIPs in the first `<devnet-name>` EELS release
+(`v7.3.0`, following the previous `v7.2.0` release). This scope is tentative —
+EIPs may be added, dropped, or deferred as decisions land in ACD and during
+implementation.
 
 ### Instructions
 
@@ -81,27 +82,14 @@ The most difficult changes are expected to be `<...>`. Highlight any cross-EIP
 alignment, ordering dependencies, or testing-framework work that could block the
 release here.
 
-#### Guidance for Marking Items Complete
-
-An item should only be checked off once it is considered *stable*. In this
-context, stable means:
-
-- No major issues or ambiguities are still being uncovered in the specification or tests.
-- There are no open discussion points awaiting resolution.
-- Client implementations have been consistently passing the tests for at least a week.
-
-It is ultimately up to the owners' discretion to decide when an item should be
-marked as complete, using this guidance as the basis for that decision.
-
 ### Specification + Testing Status
 
-- [ ] All included EIP specifications merged to the corresponding `forks/<fork>` branch.
-- [ ] Devnet branch (e.g. `devnets/<devnet-name>`) created and rebased on the target fork.
+- [ ] All included EIP specifications merged to the corresponding `feat-devnet-N` branch.
+- [ ] Devnet branch (`feat-devnet-N`) created and rebased on the target fork.
 - [ ] Required testing framework modifications implemented.
 - [ ] Test suites for all included EIPs implemented.
 - [ ] No regressions or failures in tests from prior forks (including static tests).
 - [ ] Fixtures generated and released for the devnet.
-- [ ] Ran tests using `execute` to ensure compatibility with live networks.
 
 ### Client Readiness
 

--- a/.github/ISSUE_TEMPLATE/devnet-tracker.md
+++ b/.github/ISSUE_TEMPLATE/devnet-tracker.md
@@ -1,13 +1,13 @@
 ---
 name: Devnet Tracker
 about: Track EL test release readiness for a devnet (tests-<feat>-devnet@vX.Y.Z)
-title: 'tests-<feat>-devnet@vX.Y.Z Tracker'
+title: '<feat>-devnet@vX.Y.Z Tracker'
 labels: C-tracker, P-high
 assignees: ''
 
 ---
 
-## tests-`<feat>`-devnet@v`X.Y.Z`
+## `<feat>`-devnet@v`X.Y.Z`
 
 > [!NOTE]
 > This is an **execution layer (EL) only** tracker — it does not cover

--- a/.github/ISSUE_TEMPLATE/devnet-tracker.md
+++ b/.github/ISSUE_TEMPLATE/devnet-tracker.md
@@ -1,0 +1,128 @@
+---
+name: Devnet Tracker
+about: Track specification, testing, and launch readiness for a devnet
+title: '<devnet-name> Tracker'
+labels: A-spec-specs, A-spec-tests, C-eip, C-test
+assignees: ''
+
+---
+
+## <devnet-name>
+
+### Target Fork
+
+**<fork>**
+
+### Overview
+
+<!--
+    Briefly describe the purpose of this devnet, its scope, and any relevant
+    links (devnet specs repo, ACD notes, configuration / genesis).
+-->
+
+- **Specs**: <!-- link to the devnet specs / config repo -->
+- **Target release**: <!-- e.g. v7.3.0 or "TBD" -->
+- **Test release date**: <!-- YYYY-MM-DD or "TBD" — aim for 5 days before the devnet -->
+- **Devnet launch date**: <!-- YYYY-MM-DD or "TBD" -->
+
+> [!NOTE]
+> Aim to cut the test (fixture) release **at least 5 days before** the devnet
+> launch, to give client teams time to integrate and run them.
+
+### Aim
+
+<!--
+    A short statement of what we're aiming for in this devnet release.
+    Be explicit that the scope is tentative and will change.
+-->
+
+We aim to include the following EIPs in the first `<devnet-name>` EELS release.
+This scope is tentative — EIPs may be added, dropped, or deferred as decisions
+land in ACD and during implementation.
+
+### Instructions
+
+- [ ] Assign issue to the devnet coordination owner(s).
+- [ ] Add the issue to the target fork milestone if applicable.
+- [ ] Link each included EIP's [EIP Implementation Tracker](https://github.com/ethereum/execution-specs/issues/new?template=eip-tracker.md) below.
+
+> [!IMPORTANT]
+> Per-EIP specification and testing progress is tracked in the individual EIP
+> Implementation Tracker issues. This issue tracks devnet-level readiness only.
+
+### Proposed Scope
+
+<!--
+    Group EIPs by confidence. Move EIPs between groups as decisions are made,
+    and check an EIP off in "Confirmed" once its tracker issue is stable.
+-->
+
+#### Confirmed
+
+- [ ] [EIP-<eip-number>](https://eips.ethereum.org/EIPS/eip-<eip-number>) — #<tracker-issue>
+- [ ] [EIP-<eip-number>](https://eips.ethereum.org/EIPS/eip-<eip-number>) — #<tracker-issue>
+
+#### To Be Discussed
+
+<!-- Items pending an ACD / owner decision. Link the relevant EIP PR. -->
+
+- [ ] [EIP-<eip-number>](https://eips.ethereum.org/EIPS/eip-<eip-number>) — <reason / link to discussion PR>
+
+#### At Risk / Likely Dropped
+
+<!-- EIPs that may not make this devnet. -->
+
+- [ ] [EIP-<eip-number>](https://eips.ethereum.org/EIPS/eip-<eip-number>) — <reason>
+
+### Notes & Risks
+
+<!--
+    Call out the integration challenges and known hard spots, e.g. cross-EIP
+    alignment, ordering dependencies, framework changes.
+-->
+
+The most difficult changes are expected to be `<...>`. Highlight any cross-EIP
+alignment, ordering dependencies, or testing-framework work that could block the
+release here.
+
+#### Guidance for Marking Items Complete
+
+An item should only be checked off once it is considered *stable*. In this
+context, stable means:
+
+- No major issues or ambiguities are still being uncovered in the specification or tests.
+- There are no open discussion points awaiting resolution.
+- Client implementations have been consistently passing the tests for at least a week.
+
+It is ultimately up to the owners' discretion to decide when an item should be
+marked as complete, using this guidance as the basis for that decision.
+
+### Specification + Testing Status
+
+- [ ] All included EIP specifications merged to the corresponding `forks/<fork>` branch.
+- [ ] Devnet branch (e.g. `devnets/<devnet-name>`) created and rebased on the target fork.
+- [ ] Required testing framework modifications implemented.
+- [ ] Test suites for all included EIPs implemented.
+- [ ] No regressions or failures in tests from prior forks (including static tests).
+- [ ] Fixtures generated and released for the devnet.
+- [ ] Ran tests using `execute` to ensure compatibility with live networks.
+
+### Client Readiness
+
+<!--
+    Track which client implementations are ready for the devnet.
+-->
+
+- [ ] geth
+- [ ] erigon
+- [ ] besu
+- [ ] nethermind
+- [ ] reth
+- [ ] ethrex
+
+### Process Status
+
+- [ ] Hive tests passing on at least two implementations.
+- [ ] Interop / cross-client testing completed.
+- [ ] Devnet launched.
+- [ ] Post-launch issues triaged and tracked.


### PR DESCRIPTION
## 🗒️ Description
Add a `Devnet Tracker` issue template (`.github/ISSUE_TEMPLATE/devnet-tracker.md`) to track test release readiness at the devnet level — complementing the per-EIP `EIP Implementation Tracker`.

Adopts the `tests-<feat>-devnet@vX.Y.Z` release scheme (where `X` is the devnet number, `Y`/`Z` follow consensus-test semantics) and captures, as first-class sections: release tag, specs branch, test-release and devnet launch dates (with a reminder to cut the test release at least 5 days before the devnet), a follow-up link for test-only releases, a tentative aim, proposed scope grouped by confidence (Confirmed / To Be Discussed / At Risk), notes & risks, spec/test, client-readiness and process checklists, plus a closure step linking the fixture release tag.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![A very surprised cat](https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Surprised_Cat.jpg/960px-Surprised_Cat.jpg)

