### PR TITLE
chore(spec-specs): EIP-8037 backports and refactors

### DIFF
--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -657,9 +657,8 @@ def calculate_intrinsic_cost(tx: Transaction) -> IntrinsicGasCost:
             tx.authorizations
         )
         auth_state_gas = (
-            (StateGasCosts.NEW_ACCOUNT + StateGasCosts.AUTH_BASE)
-            * ulen(tx.authorizations)
-        )
+            StateGasCosts.NEW_ACCOUNT + StateGasCosts.AUTH_BASE
+        ) * ulen(tx.authorizations)
 
     # EIP-7976 floor tokens: all calldata bytes count uniformly.
     floor_tokens_in_calldata = ulen(tx.data) * GasCosts.TX_DATA_TOKEN_STANDARD

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -46,9 +46,7 @@ class StateGasCosts:
     NEW_ACCOUNT: Final[Uint] = (
         STATE_BYTES_PER_NEW_ACCOUNT * COST_PER_STATE_BYTE
     )
-    AUTH_BASE: Final[Uint] = (
-        STATE_BYTES_PER_AUTH_BASE * COST_PER_STATE_BYTE
-    )
+    AUTH_BASE: Final[Uint] = STATE_BYTES_PER_AUTH_BASE * COST_PER_STATE_BYTE
 
 
 # These values may be patched at runtime by a future gas repricing utility

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -26,14 +26,14 @@ from . import Evm
 from .exceptions import OutOfGasError
 
 
+# These may be patched at runtime by a future gas repricing utility to
+# fast-iterate on state-byte costs.
 class StateGasCosts:
     """
     EIP-8037 state-gas constants.
 
     Kept separate from `GasCosts` because these carry a different unit:
     state-byte counts that convert into gas via `COST_PER_STATE_BYTE`.
-    Like `GasCosts`, these may be patched at runtime by a future gas
-    repricing utility to fast-iterate on state-byte costs.
     """
 
     COST_PER_STATE_BYTE: Final[Uint] = Uint(1530)

--- a/src/ethereum/forks/amsterdam/vm/instructions/storage.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/storage.py
@@ -97,8 +97,6 @@ def sstore(evm: Evm) -> None:
         gas_cost += GasCosts.COLD_STORAGE_ACCESS
 
     if original_value == current_value and current_value != new_value:
-        if original_value == 0:
-            state_gas = StateGasCosts.STORAGE_SET
         # charge regular cost for the operation, even when we
         # already charge state gas for state creation
         gas_cost += GasCosts.COLD_STORAGE_WRITE - GasCosts.COLD_STORAGE_ACCESS
@@ -117,14 +115,20 @@ def sstore(evm: Evm) -> None:
 
         if original_value == new_value:
             # Storage slot being restored to its original value
-            if original_value == 0:
-                # Slot set then cleared: refund the state gas charge.
-                credit_state_gas_refund(evm, StateGasCosts.STORAGE_SET)
             evm.refund_counter += int(
                 GasCosts.COLD_STORAGE_WRITE
                 - GasCosts.COLD_STORAGE_ACCESS
                 - GasCosts.WARM_ACCESS
             )
+
+    if original_value == current_value and current_value != new_value:
+        if original_value == 0:
+            state_gas = StateGasCosts.STORAGE_SET
+
+    if current_value != new_value and original_value == new_value:
+        if original_value == 0:
+            # Slot set then cleared: refund the state gas charge.
+            credit_state_gas_refund(evm, StateGasCosts.STORAGE_SET)
 
     # Charge regular gas before state gas so that a regular-gas OOG
     # does not consume state gas that would inflate the parent's

--- a/src/ethereum/forks/amsterdam/vm/instructions/storage.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/storage.py
@@ -89,7 +89,6 @@ def sstore(evm: Evm) -> None:
     )
     current_value = get_storage(tx_state, evm.message.current_target, key)
 
-    state_gas_storage_set = StateGasCosts.STORAGE_SET
     gas_cost = Uint(0)
     state_gas = Uint(0)
 
@@ -99,7 +98,7 @@ def sstore(evm: Evm) -> None:
 
     if original_value == current_value and current_value != new_value:
         if original_value == 0:
-            state_gas = state_gas_storage_set
+            state_gas = StateGasCosts.STORAGE_SET
         # charge regular cost for the operation, even when we
         # already charge state gas for state creation
         gas_cost += GasCosts.COLD_STORAGE_WRITE - GasCosts.COLD_STORAGE_ACCESS
@@ -120,7 +119,7 @@ def sstore(evm: Evm) -> None:
             # Storage slot being restored to its original value
             if original_value == 0:
                 # Slot set then cleared: refund the state gas charge.
-                credit_state_gas_refund(evm, state_gas_storage_set)
+                credit_state_gas_refund(evm, StateGasCosts.STORAGE_SET)
             evm.refund_counter += int(
                 GasCosts.COLD_STORAGE_WRITE
                 - GasCosts.COLD_STORAGE_ACCESS

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -11,6 +11,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
+from dataclasses import dataclass
+
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -302,23 +304,29 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def generic_call(
-    evm: Evm,
-    gas: Uint,
-    state_gas_reservoir: Uint,
-    value: U256,
-    caller: Address,
-    to: Address,
-    code_address: Address,
-    should_transfer_value: bool,
-    is_staticcall: bool,
-    memory_input_start_position: U256,
-    memory_input_size: U256,
-    memory_output_start_position: U256,
-    memory_output_size: U256,
-    code: Bytes,
-    disable_precompiles: bool,
-) -> None:
+@dataclass
+class GenericCallParams:
+    """
+    Parameters for the core logic of the `CALL*` family of opcodes.
+    """
+
+    gas: Uint
+    state_gas_reservoir: Uint
+    value: U256
+    caller: Address
+    to: Address
+    code_address: Address
+    should_transfer_value: bool
+    is_staticcall: bool
+    memory_input_start_position: U256
+    memory_input_size: U256
+    memory_output_start_position: U256
+    memory_output_size: U256
+    code: Bytes
+    disable_precompiles: bool
+
+
+def generic_call(evm: Evm, params: GenericCallParams) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -327,33 +335,35 @@ def generic_call(
     evm.return_data = b""
 
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
-        evm.gas_left += gas
-        evm.state_gas_left += state_gas_reservoir
+        evm.gas_left += params.gas
+        evm.state_gas_left += params.state_gas_reservoir
         push(evm.stack, U256(0))
         return
 
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm.memory,
+        params.memory_input_start_position,
+        params.memory_input_size,
     )
 
     child_message = Message(
         block_env=evm.message.block_env,
         tx_env=evm.message.tx_env,
-        caller=caller,
-        target=to,
-        gas=gas,
-        state_gas_reservoir=state_gas_reservoir,
-        value=value,
+        caller=params.caller,
+        target=params.to,
+        gas=params.gas,
+        state_gas_reservoir=params.state_gas_reservoir,
+        value=params.value,
         data=call_data,
-        code=code,
-        current_target=to,
+        code=params.code,
+        current_target=params.to,
         depth=evm.message.depth + Uint(1),
-        code_address=code_address,
-        should_transfer_value=should_transfer_value,
-        is_static=True if is_staticcall else evm.message.is_static,
+        code_address=params.code_address,
+        should_transfer_value=params.should_transfer_value,
+        is_static=(True if params.is_staticcall else evm.message.is_static),
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
-        disable_precompiles=disable_precompiles,
+        disable_precompiles=params.disable_precompiles,
         parent_evm=evm,
     )
 
@@ -368,10 +378,12 @@ def generic_call(
         evm.return_data = child_evm.output
         push(evm.stack, CALL_SUCCESS)
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    actual_output_size = min(
+        params.memory_output_size, U256(len(child_evm.output))
+    )
     memory_write(
         evm.memory,
-        memory_output_start_position,
+        params.memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
 
@@ -473,20 +485,22 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            call_state_gas_reservoir,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
-            code,
-            is_delegated,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                state_gas_reservoir=call_state_gas_reservoir,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+                code=code,
+                disable_precompiles=is_delegated,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -586,20 +600,22 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            call_state_gas_reservoir,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
-            code,
-            is_delegated,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                state_gas_reservoir=call_state_gas_reservoir,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+                code=code,
+                disable_precompiles=is_delegated,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -752,20 +768,22 @@ def delegatecall(evm: Evm) -> None:
 
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        call_state_gas_reservoir,
-        evm.message.value,
-        evm.message.caller,
-        evm.message.current_target,
-        code_address,
-        False,
-        False,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
-        code,
-        is_delegated,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            state_gas_reservoir=call_state_gas_reservoir,
+            value=evm.message.value,
+            caller=evm.message.caller,
+            to=evm.message.current_target,
+            code_address=code_address,
+            should_transfer_value=False,
+            is_staticcall=False,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+            code=code,
+            disable_precompiles=is_delegated,
+        ),
     )
 
     # PROGRAM COUNTER
@@ -849,20 +867,22 @@ def staticcall(evm: Evm) -> None:
 
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        call_state_gas_reservoir,
-        U256(0),
-        evm.message.current_target,
-        to,
-        code_address,
-        True,
-        True,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
-        code,
-        is_delegated,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            state_gas_reservoir=call_state_gas_reservoir,
+            value=U256(0),
+            caller=evm.message.current_target,
+            to=to,
+            code_address=code_address,
+            should_transfer_value=True,
+            is_staticcall=True,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+            code=code,
+            disable_precompiles=is_delegated,
+        ),
     )
 
     # PROGRAM COUNTER

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -305,7 +305,7 @@ def return_(evm: Evm) -> None:
 
 
 @dataclass
-class GenericCallParams:
+class GenericCall:
     """
     Parameters for the core logic of the `CALL*` family of opcodes.
     """
@@ -326,7 +326,7 @@ class GenericCallParams:
     disable_precompiles: bool
 
 
-def generic_call(evm: Evm, params: GenericCallParams) -> None:
+def generic_call(evm: Evm, params: GenericCall) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -360,7 +360,7 @@ def generic_call(evm: Evm, params: GenericCallParams) -> None:
         depth=evm.message.depth + Uint(1),
         code_address=params.code_address,
         should_transfer_value=params.should_transfer_value,
-        is_static=(True if params.is_staticcall else evm.message.is_static),
+        is_static=params.is_staticcall or evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
         disable_precompiles=params.disable_precompiles,
@@ -485,7 +485,7 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 state_gas_reservoir=call_state_gas_reservoir,
                 value=value,
@@ -600,7 +600,7 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 state_gas_reservoir=call_state_gas_reservoir,
                 value=value,
@@ -768,7 +768,7 @@ def delegatecall(evm: Evm) -> None:
 
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             state_gas_reservoir=call_state_gas_reservoir,
             value=evm.message.value,
@@ -867,7 +867,7 @@ def staticcall(evm: Evm) -> None:
 
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             state_gas_reservoir=call_state_gas_reservoir,
             value=U256(0),

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -94,12 +94,12 @@ class MessageCallOutput:
     """
 
     gas_left: Uint
-    state_gas_left: Uint
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
     error: Optional[EthereumException]
     return_data: Bytes
+    state_gas_left: Uint
     regular_gas_used: Uint
     state_gas_used: int
     state_refund: Uint
@@ -131,12 +131,12 @@ def process_message_call(message: Message) -> MessageCallOutput:
         if is_collision:
             return MessageCallOutput(
                 gas_left=Uint(0),
-                state_gas_left=message.state_gas_reservoir,
                 refund_counter=U256(0),
                 logs=tuple(),
                 accounts_to_delete=set(),
                 error=AddressCollision(),
                 return_data=Bytes(b""),
+                state_gas_left=message.state_gas_reservoir,
                 regular_gas_used=message.gas,
                 state_gas_used=0,
                 state_refund=Uint(0),
@@ -174,12 +174,12 @@ def process_message_call(message: Message) -> MessageCallOutput:
 
     return MessageCallOutput(
         gas_left=evm.gas_left,
-        state_gas_left=evm.state_gas_left,
         refund_counter=refund_counter,
         logs=logs,
         accounts_to_delete=accounts_to_delete,
         error=evm.error,
         return_data=evm.output,
+        state_gas_left=evm.state_gas_left,
         regular_gas_used=evm.regular_gas_used,
         state_gas_used=evm.state_gas_used,
         state_refund=state_refund,

--- a/src/ethereum/forks/arrow_glacier/vm/instructions/system.py
+++ b/src/ethereum/forks/arrow_glacier/vm/instructions/system.py
@@ -11,6 +11,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
+from dataclasses import dataclass
+
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -246,20 +248,26 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def generic_call(
-    evm: Evm,
-    gas: Uint,
-    value: U256,
-    caller: Address,
-    to: Address,
-    code_address: Address,
-    should_transfer_value: bool,
-    is_staticcall: bool,
-    memory_input_start_position: U256,
-    memory_input_size: U256,
-    memory_output_start_position: U256,
-    memory_output_size: U256,
-) -> None:
+@dataclass
+class GenericCallParams:
+    """
+    Parameters for the core logic of the `CALL*` family of opcodes.
+    """
+
+    gas: Uint
+    value: U256
+    caller: Address
+    to: Address
+    code_address: Address
+    should_transfer_value: bool
+    is_staticcall: bool
+    memory_input_start_position: U256
+    memory_input_size: U256
+    memory_output_start_position: U256
+    memory_output_size: U256
+
+
+def generic_call(evm: Evm, params: GenericCallParams) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -268,29 +276,31 @@ def generic_call(
     evm.return_data = b""
 
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
-        evm.gas_left += gas
+        evm.gas_left += params.gas
         push(evm.stack, U256(0))
         return
 
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm.memory,
+        params.memory_input_start_position,
+        params.memory_input_size,
     )
-    account = get_account(evm.message.tx_env.state, code_address)
+    account = get_account(evm.message.tx_env.state, params.code_address)
     code = get_code(evm.message.tx_env.state, account.code_hash)
     child_message = Message(
         block_env=evm.message.block_env,
         tx_env=evm.message.tx_env,
-        caller=caller,
-        target=to,
-        gas=gas,
-        value=value,
+        caller=params.caller,
+        target=params.to,
+        gas=params.gas,
+        value=params.value,
         data=call_data,
         code=code,
-        current_target=to,
+        current_target=params.to,
         depth=evm.message.depth + Uint(1),
-        code_address=code_address,
-        should_transfer_value=should_transfer_value,
-        is_static=True if is_staticcall else evm.message.is_static,
+        code_address=params.code_address,
+        should_transfer_value=params.should_transfer_value,
+        is_static=True if params.is_staticcall else evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
         parent_evm=evm,
@@ -306,10 +316,12 @@ def generic_call(
         evm.return_data = child_evm.output
         push(evm.stack, U256(1))
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    actual_output_size = min(
+        params.memory_output_size, U256(len(child_evm.output))
+    )
     memory_write(
         evm.memory,
-        memory_output_start_position,
+        params.memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
 
@@ -375,17 +387,19 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -450,17 +464,19 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -578,17 +594,19 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        evm.message.value,
-        evm.message.caller,
-        evm.message.current_target,
-        code_address,
-        False,
-        False,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=evm.message.value,
+            caller=evm.message.caller,
+            to=evm.message.current_target,
+            code_address=code_address,
+            should_transfer_value=False,
+            is_staticcall=False,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+        ),
     )
 
     # PROGRAM COUNTER
@@ -643,17 +661,19 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        U256(0),
-        evm.message.current_target,
-        to,
-        code_address,
-        True,
-        True,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=U256(0),
+            caller=evm.message.current_target,
+            to=to,
+            code_address=code_address,
+            should_transfer_value=True,
+            is_staticcall=True,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+        ),
     )
 
     # PROGRAM COUNTER

--- a/src/ethereum/forks/arrow_glacier/vm/instructions/system.py
+++ b/src/ethereum/forks/arrow_glacier/vm/instructions/system.py
@@ -358,8 +358,8 @@ def call(evm: Evm) -> None:
         value,
         gas,
         Uint(evm.gas_left),
-        extend_memory.cost,
-        access_gas_cost + create_gas_cost + transfer_gas_cost,
+        memory_cost=extend_memory.cost,
+        extra_gas=access_gas_cost + create_gas_cost + transfer_gas_cost,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
     if evm.message.is_static and value != U256(0):

--- a/src/ethereum/forks/arrow_glacier/vm/instructions/system.py
+++ b/src/ethereum/forks/arrow_glacier/vm/instructions/system.py
@@ -249,7 +249,7 @@ def return_(evm: Evm) -> None:
 
 
 @dataclass
-class GenericCallParams:
+class GenericCall:
     """
     Parameters for the core logic of the `CALL*` family of opcodes.
     """
@@ -267,7 +267,7 @@ class GenericCallParams:
     memory_output_size: U256
 
 
-def generic_call(evm: Evm, params: GenericCallParams) -> None:
+def generic_call(evm: Evm, params: GenericCall) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -300,7 +300,7 @@ def generic_call(evm: Evm, params: GenericCallParams) -> None:
         depth=evm.message.depth + Uint(1),
         code_address=params.code_address,
         should_transfer_value=params.should_transfer_value,
-        is_static=True if params.is_staticcall else evm.message.is_static,
+        is_static=params.is_staticcall or evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
         parent_evm=evm,
@@ -387,7 +387,7 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -464,7 +464,7 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -594,7 +594,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=evm.message.value,
             caller=evm.message.caller,
@@ -661,7 +661,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=U256(0),
             caller=evm.message.current_target,

--- a/src/ethereum/forks/berlin/vm/instructions/system.py
+++ b/src/ethereum/forks/berlin/vm/instructions/system.py
@@ -249,7 +249,7 @@ def return_(evm: Evm) -> None:
 
 
 @dataclass
-class GenericCallParams:
+class GenericCall:
     """
     Parameters for the core logic of the `CALL*` family of opcodes.
     """
@@ -267,7 +267,7 @@ class GenericCallParams:
     memory_output_size: U256
 
 
-def generic_call(evm: Evm, params: GenericCallParams) -> None:
+def generic_call(evm: Evm, params: GenericCall) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -300,7 +300,7 @@ def generic_call(evm: Evm, params: GenericCallParams) -> None:
         depth=evm.message.depth + Uint(1),
         code_address=params.code_address,
         should_transfer_value=params.should_transfer_value,
-        is_static=True if params.is_staticcall else evm.message.is_static,
+        is_static=params.is_staticcall or evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
         parent_evm=evm,
@@ -387,7 +387,7 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -464,7 +464,7 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -601,7 +601,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=evm.message.value,
             caller=evm.message.caller,
@@ -668,7 +668,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=U256(0),
             caller=evm.message.current_target,

--- a/src/ethereum/forks/berlin/vm/instructions/system.py
+++ b/src/ethereum/forks/berlin/vm/instructions/system.py
@@ -11,6 +11,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
+from dataclasses import dataclass
+
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -246,20 +248,26 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def generic_call(
-    evm: Evm,
-    gas: Uint,
-    value: U256,
-    caller: Address,
-    to: Address,
-    code_address: Address,
-    should_transfer_value: bool,
-    is_staticcall: bool,
-    memory_input_start_position: U256,
-    memory_input_size: U256,
-    memory_output_start_position: U256,
-    memory_output_size: U256,
-) -> None:
+@dataclass
+class GenericCallParams:
+    """
+    Parameters for the core logic of the `CALL*` family of opcodes.
+    """
+
+    gas: Uint
+    value: U256
+    caller: Address
+    to: Address
+    code_address: Address
+    should_transfer_value: bool
+    is_staticcall: bool
+    memory_input_start_position: U256
+    memory_input_size: U256
+    memory_output_start_position: U256
+    memory_output_size: U256
+
+
+def generic_call(evm: Evm, params: GenericCallParams) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -268,29 +276,31 @@ def generic_call(
     evm.return_data = b""
 
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
-        evm.gas_left += gas
+        evm.gas_left += params.gas
         push(evm.stack, U256(0))
         return
 
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm.memory,
+        params.memory_input_start_position,
+        params.memory_input_size,
     )
-    _code_account = get_account(evm.message.tx_env.state, code_address)
+    _code_account = get_account(evm.message.tx_env.state, params.code_address)
     code = get_code(evm.message.tx_env.state, _code_account.code_hash)
     child_message = Message(
         block_env=evm.message.block_env,
         tx_env=evm.message.tx_env,
-        caller=caller,
-        target=to,
-        gas=gas,
-        value=value,
+        caller=params.caller,
+        target=params.to,
+        gas=params.gas,
+        value=params.value,
         data=call_data,
         code=code,
-        current_target=to,
+        current_target=params.to,
         depth=evm.message.depth + Uint(1),
-        code_address=code_address,
-        should_transfer_value=should_transfer_value,
-        is_static=True if is_staticcall else evm.message.is_static,
+        code_address=params.code_address,
+        should_transfer_value=params.should_transfer_value,
+        is_static=True if params.is_staticcall else evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
         parent_evm=evm,
@@ -306,10 +316,12 @@ def generic_call(
         evm.return_data = child_evm.output
         push(evm.stack, U256(1))
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    actual_output_size = min(
+        params.memory_output_size, U256(len(child_evm.output))
+    )
     memory_write(
         evm.memory,
-        memory_output_start_position,
+        params.memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
 
@@ -375,17 +387,19 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -450,17 +464,19 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -585,17 +601,19 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        evm.message.value,
-        evm.message.caller,
-        evm.message.current_target,
-        code_address,
-        False,
-        False,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=evm.message.value,
+            caller=evm.message.caller,
+            to=evm.message.current_target,
+            code_address=code_address,
+            should_transfer_value=False,
+            is_staticcall=False,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+        ),
     )
 
     # PROGRAM COUNTER
@@ -650,17 +668,19 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        U256(0),
-        evm.message.current_target,
-        to,
-        code_address,
-        True,
-        True,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=U256(0),
+            caller=evm.message.current_target,
+            to=to,
+            code_address=code_address,
+            should_transfer_value=True,
+            is_staticcall=True,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+        ),
     )
 
     # PROGRAM COUNTER

--- a/src/ethereum/forks/berlin/vm/instructions/system.py
+++ b/src/ethereum/forks/berlin/vm/instructions/system.py
@@ -358,8 +358,8 @@ def call(evm: Evm) -> None:
         value,
         gas,
         Uint(evm.gas_left),
-        extend_memory.cost,
-        access_gas_cost + create_gas_cost + transfer_gas_cost,
+        memory_cost=extend_memory.cost,
+        extra_gas=access_gas_cost + create_gas_cost + transfer_gas_cost,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
     if evm.message.is_static and value != U256(0):

--- a/src/ethereum/forks/bpo1/fork.py
+++ b/src/ethereum/forks/bpo1/fork.py
@@ -871,7 +871,7 @@ def process_transaction(
         encode_transaction(tx),
     )
 
-    intrinsic_gas, calldata_floor_gas_cost = validate_transaction(tx)
+    intrinsic = validate_transaction(tx)
 
     (
         sender,
@@ -894,7 +894,7 @@ def process_transaction(
 
     effective_gas_fee = tx.gas * effective_gas_price
 
-    gas = tx.gas - intrinsic_gas
+    gas = tx.gas - intrinsic.regular
     increment_nonce(tx_state, sender)
 
     sender_balance_after_gas_fee = (
@@ -943,7 +943,7 @@ def process_transaction(
     # Transactions with less execution_gas_used than the floor pay at the
     # floor cost.
     tx_gas_used_after_refund = max(
-        tx_gas_used_after_refund, calldata_floor_gas_cost
+        tx_gas_used_after_refund, intrinsic.calldata_floor
     )
 
     tx_gas_left = tx.gas - tx_gas_used_after_refund

--- a/src/ethereum/forks/bpo1/transactions.py
+++ b/src/ethereum/forks/bpo1/transactions.py
@@ -28,6 +28,18 @@ from .exceptions import (
 )
 from .fork_types import Authorization, VersionedHash
 
+
+@dataclass
+class IntrinsicGasCost:
+    """Intrinsic gas costs for a transaction, split by gas type."""
+
+    regular: Uint
+    """Regular execution gas (calldata, base cost, access list, etc.)."""
+
+    calldata_floor: Uint
+    """Minimum gas cost based on calldata size per [EIP-7623]."""
+
+
 TX_MAX_GAS_LIMIT = Uint(16_777_216)
 
 
@@ -506,7 +518,7 @@ def decode_transaction(tx: LegacyTransaction | Bytes) -> Transaction:
         return tx
 
 
-def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
+def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
     """
     Verifies a transaction.
 
@@ -537,8 +549,8 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     """
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
-    intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
-    if max(intrinsic_gas, calldata_floor_gas_cost) > tx.gas:
+    intrinsic = calculate_intrinsic_cost(tx)
+    if max(intrinsic.regular, intrinsic.calldata_floor) > tx.gas:
         raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
@@ -547,10 +559,10 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     if tx.gas > TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
 
-    return intrinsic_gas, calldata_floor_gas_cost
+    return intrinsic
 
 
-def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
+def calculate_intrinsic_cost(tx: Transaction) -> IntrinsicGasCost:
     """
     Calculates the gas that is charged before execution is started.
 
@@ -607,15 +619,15 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
             GasCosts.AUTH_PER_EMPTY_ACCOUNT * len(tx.authorizations)
         )
 
-    return (
-        Uint(
+    return IntrinsicGasCost(
+        regular=Uint(
             GasCosts.TX_BASE
             + data_cost
             + create_cost
             + access_list_cost
             + auth_cost
         ),
-        calldata_floor_gas_cost,
+        calldata_floor=calldata_floor_gas_cost,
     )
 
 

--- a/src/ethereum/forks/bpo1/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo1/vm/instructions/system.py
@@ -271,7 +271,7 @@ def return_(evm: Evm) -> None:
 
 
 @dataclass
-class GenericCallParams:
+class GenericCall:
     """
     Parameters for the core logic of the `CALL*` family of opcodes.
     """
@@ -291,7 +291,7 @@ class GenericCallParams:
     disable_precompiles: bool
 
 
-def generic_call(evm: Evm, params: GenericCallParams) -> None:
+def generic_call(evm: Evm, params: GenericCall) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -323,7 +323,7 @@ def generic_call(evm: Evm, params: GenericCallParams) -> None:
         depth=evm.message.depth + Uint(1),
         code_address=params.code_address,
         should_transfer_value=params.should_transfer_value,
-        is_static=True if params.is_staticcall else evm.message.is_static,
+        is_static=params.is_staticcall or evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
         disable_precompiles=params.disable_precompiles,
@@ -418,7 +418,7 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -505,7 +505,7 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -635,7 +635,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=evm.message.value,
             caller=evm.message.caller,
@@ -711,7 +711,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=U256(0),
             caller=evm.message.current_target,

--- a/src/ethereum/forks/bpo1/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo1/vm/instructions/system.py
@@ -11,6 +11,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
+from dataclasses import dataclass
+
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -268,22 +270,28 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def generic_call(
-    evm: Evm,
-    gas: Uint,
-    value: U256,
-    caller: Address,
-    to: Address,
-    code_address: Address,
-    should_transfer_value: bool,
-    is_staticcall: bool,
-    memory_input_start_position: U256,
-    memory_input_size: U256,
-    memory_output_start_position: U256,
-    memory_output_size: U256,
-    code: Bytes,
-    disable_precompiles: bool,
-) -> None:
+@dataclass
+class GenericCallParams:
+    """
+    Parameters for the core logic of the `CALL*` family of opcodes.
+    """
+
+    gas: Uint
+    value: U256
+    caller: Address
+    to: Address
+    code_address: Address
+    should_transfer_value: bool
+    is_staticcall: bool
+    memory_input_start_position: U256
+    memory_input_size: U256
+    memory_output_start_position: U256
+    memory_output_size: U256
+    code: Bytes
+    disable_precompiles: bool
+
+
+def generic_call(evm: Evm, params: GenericCallParams) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -292,31 +300,33 @@ def generic_call(
     evm.return_data = b""
 
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
-        evm.gas_left += gas
+        evm.gas_left += params.gas
         push(evm.stack, U256(0))
         return
 
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm.memory,
+        params.memory_input_start_position,
+        params.memory_input_size,
     )
 
     child_message = Message(
         block_env=evm.message.block_env,
         tx_env=evm.message.tx_env,
-        caller=caller,
-        target=to,
-        gas=gas,
-        value=value,
+        caller=params.caller,
+        target=params.to,
+        gas=params.gas,
+        value=params.value,
         data=call_data,
-        code=code,
-        current_target=to,
+        code=params.code,
+        current_target=params.to,
         depth=evm.message.depth + Uint(1),
-        code_address=code_address,
-        should_transfer_value=should_transfer_value,
-        is_static=True if is_staticcall else evm.message.is_static,
+        code_address=params.code_address,
+        should_transfer_value=params.should_transfer_value,
+        is_static=True if params.is_staticcall else evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
-        disable_precompiles=disable_precompiles,
+        disable_precompiles=params.disable_precompiles,
         parent_evm=evm,
     )
     child_evm = process_message(child_message)
@@ -330,10 +340,12 @@ def generic_call(
         evm.return_data = child_evm.output
         push(evm.stack, U256(1))
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    actual_output_size = min(
+        params.memory_output_size, U256(len(child_evm.output))
+    )
     memory_write(
         evm.memory,
-        memory_output_start_position,
+        params.memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
 
@@ -406,19 +418,21 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
-            code,
-            disable_precompiles,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+                code=code,
+                disable_precompiles=disable_precompiles,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -491,19 +505,21 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
-            code,
-            disable_precompiles,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+                code=code,
+                disable_precompiles=disable_precompiles,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -619,19 +635,21 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        evm.message.value,
-        evm.message.caller,
-        evm.message.current_target,
-        code_address,
-        False,
-        False,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
-        code,
-        disable_precompiles,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=evm.message.value,
+            caller=evm.message.caller,
+            to=evm.message.current_target,
+            code_address=code_address,
+            should_transfer_value=False,
+            is_staticcall=False,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+            code=code,
+            disable_precompiles=disable_precompiles,
+        ),
     )
 
     # PROGRAM COUNTER
@@ -693,19 +711,21 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        U256(0),
-        evm.message.current_target,
-        to,
-        code_address,
-        True,
-        True,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
-        code,
-        disable_precompiles,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=U256(0),
+            caller=evm.message.current_target,
+            to=to,
+            code_address=code_address,
+            should_transfer_value=True,
+            is_staticcall=True,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+            code=code,
+            disable_precompiles=disable_precompiles,
+        ),
     )
 
     # PROGRAM COUNTER

--- a/src/ethereum/forks/bpo1/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo1/vm/instructions/system.py
@@ -389,8 +389,8 @@ def call(evm: Evm) -> None:
         value,
         gas,
         Uint(evm.gas_left),
-        extend_memory.cost,
-        access_gas_cost + create_gas_cost + transfer_gas_cost,
+        memory_cost=extend_memory.cost,
+        extra_gas=access_gas_cost + create_gas_cost + transfer_gas_cost,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
     if evm.message.is_static and value != U256(0):

--- a/src/ethereum/forks/bpo2/fork.py
+++ b/src/ethereum/forks/bpo2/fork.py
@@ -871,7 +871,7 @@ def process_transaction(
         encode_transaction(tx),
     )
 
-    intrinsic_gas, calldata_floor_gas_cost = validate_transaction(tx)
+    intrinsic = validate_transaction(tx)
 
     (
         sender,
@@ -894,7 +894,7 @@ def process_transaction(
 
     effective_gas_fee = tx.gas * effective_gas_price
 
-    gas = tx.gas - intrinsic_gas
+    gas = tx.gas - intrinsic.regular
     increment_nonce(tx_state, sender)
 
     sender_balance_after_gas_fee = (
@@ -943,7 +943,7 @@ def process_transaction(
     # Transactions with less execution_gas_used than the floor pay at the
     # floor cost.
     tx_gas_used_after_refund = max(
-        tx_gas_used_after_refund, calldata_floor_gas_cost
+        tx_gas_used_after_refund, intrinsic.calldata_floor
     )
 
     tx_gas_left = tx.gas - tx_gas_used_after_refund

--- a/src/ethereum/forks/bpo2/transactions.py
+++ b/src/ethereum/forks/bpo2/transactions.py
@@ -28,6 +28,18 @@ from .exceptions import (
 )
 from .fork_types import Authorization, VersionedHash
 
+
+@dataclass
+class IntrinsicGasCost:
+    """Intrinsic gas costs for a transaction, split by gas type."""
+
+    regular: Uint
+    """Regular execution gas (calldata, base cost, access list, etc.)."""
+
+    calldata_floor: Uint
+    """Minimum gas cost based on calldata size per [EIP-7623]."""
+
+
 TX_MAX_GAS_LIMIT = Uint(16_777_216)
 
 
@@ -506,7 +518,7 @@ def decode_transaction(tx: LegacyTransaction | Bytes) -> Transaction:
         return tx
 
 
-def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
+def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
     """
     Verifies a transaction.
 
@@ -537,8 +549,8 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     """
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
-    intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
-    if max(intrinsic_gas, calldata_floor_gas_cost) > tx.gas:
+    intrinsic = calculate_intrinsic_cost(tx)
+    if max(intrinsic.regular, intrinsic.calldata_floor) > tx.gas:
         raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
@@ -547,10 +559,10 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     if tx.gas > TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
 
-    return intrinsic_gas, calldata_floor_gas_cost
+    return intrinsic
 
 
-def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
+def calculate_intrinsic_cost(tx: Transaction) -> IntrinsicGasCost:
     """
     Calculates the gas that is charged before execution is started.
 
@@ -607,15 +619,15 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
             GasCosts.AUTH_PER_EMPTY_ACCOUNT * len(tx.authorizations)
         )
 
-    return (
-        Uint(
+    return IntrinsicGasCost(
+        regular=Uint(
             GasCosts.TX_BASE
             + data_cost
             + create_cost
             + access_list_cost
             + auth_cost
         ),
-        calldata_floor_gas_cost,
+        calldata_floor=calldata_floor_gas_cost,
     )
 
 

--- a/src/ethereum/forks/bpo2/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo2/vm/instructions/system.py
@@ -270,7 +270,7 @@ def return_(evm: Evm) -> None:
 
 
 @dataclass
-class GenericCallParams:
+class GenericCall:
     """
     Parameters for the core logic of the `CALL*` family of opcodes.
     """
@@ -290,7 +290,7 @@ class GenericCallParams:
     disable_precompiles: bool
 
 
-def generic_call(evm: Evm, params: GenericCallParams) -> None:
+def generic_call(evm: Evm, params: GenericCall) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -322,7 +322,7 @@ def generic_call(evm: Evm, params: GenericCallParams) -> None:
         depth=evm.message.depth + Uint(1),
         code_address=params.code_address,
         should_transfer_value=params.should_transfer_value,
-        is_static=True if params.is_staticcall else evm.message.is_static,
+        is_static=params.is_staticcall or evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
         disable_precompiles=params.disable_precompiles,
@@ -417,7 +417,7 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -504,7 +504,7 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -634,7 +634,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=evm.message.value,
             caller=evm.message.caller,
@@ -710,7 +710,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=U256(0),
             caller=evm.message.current_target,

--- a/src/ethereum/forks/bpo2/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo2/vm/instructions/system.py
@@ -388,8 +388,8 @@ def call(evm: Evm) -> None:
         value,
         gas,
         Uint(evm.gas_left),
-        extend_memory.cost,
-        access_gas_cost + create_gas_cost + transfer_gas_cost,
+        memory_cost=extend_memory.cost,
+        extra_gas=access_gas_cost + create_gas_cost + transfer_gas_cost,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
     if evm.message.is_static and value != U256(0):

--- a/src/ethereum/forks/bpo2/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo2/vm/instructions/system.py
@@ -11,6 +11,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
+from dataclasses import dataclass
+
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -267,22 +269,28 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def generic_call(
-    evm: Evm,
-    gas: Uint,
-    value: U256,
-    caller: Address,
-    to: Address,
-    code_address: Address,
-    should_transfer_value: bool,
-    is_staticcall: bool,
-    memory_input_start_position: U256,
-    memory_input_size: U256,
-    memory_output_start_position: U256,
-    memory_output_size: U256,
-    code: Bytes,
-    disable_precompiles: bool,
-) -> None:
+@dataclass
+class GenericCallParams:
+    """
+    Parameters for the core logic of the `CALL*` family of opcodes.
+    """
+
+    gas: Uint
+    value: U256
+    caller: Address
+    to: Address
+    code_address: Address
+    should_transfer_value: bool
+    is_staticcall: bool
+    memory_input_start_position: U256
+    memory_input_size: U256
+    memory_output_start_position: U256
+    memory_output_size: U256
+    code: Bytes
+    disable_precompiles: bool
+
+
+def generic_call(evm: Evm, params: GenericCallParams) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -291,31 +299,33 @@ def generic_call(
     evm.return_data = b""
 
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
-        evm.gas_left += gas
+        evm.gas_left += params.gas
         push(evm.stack, U256(0))
         return
 
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm.memory,
+        params.memory_input_start_position,
+        params.memory_input_size,
     )
 
     child_message = Message(
         block_env=evm.message.block_env,
         tx_env=evm.message.tx_env,
-        caller=caller,
-        target=to,
-        gas=gas,
-        value=value,
+        caller=params.caller,
+        target=params.to,
+        gas=params.gas,
+        value=params.value,
         data=call_data,
-        code=code,
-        current_target=to,
+        code=params.code,
+        current_target=params.to,
         depth=evm.message.depth + Uint(1),
-        code_address=code_address,
-        should_transfer_value=should_transfer_value,
-        is_static=True if is_staticcall else evm.message.is_static,
+        code_address=params.code_address,
+        should_transfer_value=params.should_transfer_value,
+        is_static=True if params.is_staticcall else evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
-        disable_precompiles=disable_precompiles,
+        disable_precompiles=params.disable_precompiles,
         parent_evm=evm,
     )
     child_evm = process_message(child_message)
@@ -329,10 +339,12 @@ def generic_call(
         evm.return_data = child_evm.output
         push(evm.stack, U256(1))
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    actual_output_size = min(
+        params.memory_output_size, U256(len(child_evm.output))
+    )
     memory_write(
         evm.memory,
-        memory_output_start_position,
+        params.memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
 
@@ -405,19 +417,21 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
-            code,
-            disable_precompiles,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+                code=code,
+                disable_precompiles=disable_precompiles,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -490,19 +504,21 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
-            code,
-            disable_precompiles,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+                code=code,
+                disable_precompiles=disable_precompiles,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -618,19 +634,21 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        evm.message.value,
-        evm.message.caller,
-        evm.message.current_target,
-        code_address,
-        False,
-        False,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
-        code,
-        disable_precompiles,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=evm.message.value,
+            caller=evm.message.caller,
+            to=evm.message.current_target,
+            code_address=code_address,
+            should_transfer_value=False,
+            is_staticcall=False,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+            code=code,
+            disable_precompiles=disable_precompiles,
+        ),
     )
 
     # PROGRAM COUNTER
@@ -692,19 +710,21 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        U256(0),
-        evm.message.current_target,
-        to,
-        code_address,
-        True,
-        True,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
-        code,
-        disable_precompiles,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=U256(0),
+            caller=evm.message.current_target,
+            to=to,
+            code_address=code_address,
+            should_transfer_value=True,
+            is_staticcall=True,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+            code=code,
+            disable_precompiles=disable_precompiles,
+        ),
     )
 
     # PROGRAM COUNTER

--- a/src/ethereum/forks/bpo3/fork.py
+++ b/src/ethereum/forks/bpo3/fork.py
@@ -871,7 +871,7 @@ def process_transaction(
         encode_transaction(tx),
     )
 
-    intrinsic_gas, calldata_floor_gas_cost = validate_transaction(tx)
+    intrinsic = validate_transaction(tx)
 
     (
         sender,
@@ -894,7 +894,7 @@ def process_transaction(
 
     effective_gas_fee = tx.gas * effective_gas_price
 
-    gas = tx.gas - intrinsic_gas
+    gas = tx.gas - intrinsic.regular
     increment_nonce(tx_state, sender)
 
     sender_balance_after_gas_fee = (
@@ -943,7 +943,7 @@ def process_transaction(
     # Transactions with less execution_gas_used than the floor pay at the
     # floor cost.
     tx_gas_used_after_refund = max(
-        tx_gas_used_after_refund, calldata_floor_gas_cost
+        tx_gas_used_after_refund, intrinsic.calldata_floor
     )
 
     tx_gas_left = tx.gas - tx_gas_used_after_refund

--- a/src/ethereum/forks/bpo3/transactions.py
+++ b/src/ethereum/forks/bpo3/transactions.py
@@ -28,6 +28,18 @@ from .exceptions import (
 )
 from .fork_types import Authorization, VersionedHash
 
+
+@dataclass
+class IntrinsicGasCost:
+    """Intrinsic gas costs for a transaction, split by gas type."""
+
+    regular: Uint
+    """Regular execution gas (calldata, base cost, access list, etc.)."""
+
+    calldata_floor: Uint
+    """Minimum gas cost based on calldata size per [EIP-7623]."""
+
+
 TX_MAX_GAS_LIMIT = Uint(16_777_216)
 
 
@@ -506,7 +518,7 @@ def decode_transaction(tx: LegacyTransaction | Bytes) -> Transaction:
         return tx
 
 
-def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
+def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
     """
     Verifies a transaction.
 
@@ -537,8 +549,8 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     """
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
-    intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
-    if max(intrinsic_gas, calldata_floor_gas_cost) > tx.gas:
+    intrinsic = calculate_intrinsic_cost(tx)
+    if max(intrinsic.regular, intrinsic.calldata_floor) > tx.gas:
         raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
@@ -547,10 +559,10 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     if tx.gas > TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
 
-    return intrinsic_gas, calldata_floor_gas_cost
+    return intrinsic
 
 
-def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
+def calculate_intrinsic_cost(tx: Transaction) -> IntrinsicGasCost:
     """
     Calculates the gas that is charged before execution is started.
 
@@ -607,15 +619,15 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
             GasCosts.AUTH_PER_EMPTY_ACCOUNT * len(tx.authorizations)
         )
 
-    return (
-        Uint(
+    return IntrinsicGasCost(
+        regular=Uint(
             GasCosts.TX_BASE
             + data_cost
             + create_cost
             + access_list_cost
             + auth_cost
         ),
-        calldata_floor_gas_cost,
+        calldata_floor=calldata_floor_gas_cost,
     )
 
 

--- a/src/ethereum/forks/bpo3/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo3/vm/instructions/system.py
@@ -270,7 +270,7 @@ def return_(evm: Evm) -> None:
 
 
 @dataclass
-class GenericCallParams:
+class GenericCall:
     """
     Parameters for the core logic of the `CALL*` family of opcodes.
     """
@@ -290,7 +290,7 @@ class GenericCallParams:
     disable_precompiles: bool
 
 
-def generic_call(evm: Evm, params: GenericCallParams) -> None:
+def generic_call(evm: Evm, params: GenericCall) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -322,7 +322,7 @@ def generic_call(evm: Evm, params: GenericCallParams) -> None:
         depth=evm.message.depth + Uint(1),
         code_address=params.code_address,
         should_transfer_value=params.should_transfer_value,
-        is_static=True if params.is_staticcall else evm.message.is_static,
+        is_static=params.is_staticcall or evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
         disable_precompiles=params.disable_precompiles,
@@ -417,7 +417,7 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -504,7 +504,7 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -634,7 +634,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=evm.message.value,
             caller=evm.message.caller,
@@ -710,7 +710,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=U256(0),
             caller=evm.message.current_target,

--- a/src/ethereum/forks/bpo3/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo3/vm/instructions/system.py
@@ -388,8 +388,8 @@ def call(evm: Evm) -> None:
         value,
         gas,
         Uint(evm.gas_left),
-        extend_memory.cost,
-        access_gas_cost + create_gas_cost + transfer_gas_cost,
+        memory_cost=extend_memory.cost,
+        extra_gas=access_gas_cost + create_gas_cost + transfer_gas_cost,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
     if evm.message.is_static and value != U256(0):

--- a/src/ethereum/forks/bpo3/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo3/vm/instructions/system.py
@@ -11,6 +11,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
+from dataclasses import dataclass
+
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -267,22 +269,28 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def generic_call(
-    evm: Evm,
-    gas: Uint,
-    value: U256,
-    caller: Address,
-    to: Address,
-    code_address: Address,
-    should_transfer_value: bool,
-    is_staticcall: bool,
-    memory_input_start_position: U256,
-    memory_input_size: U256,
-    memory_output_start_position: U256,
-    memory_output_size: U256,
-    code: Bytes,
-    disable_precompiles: bool,
-) -> None:
+@dataclass
+class GenericCallParams:
+    """
+    Parameters for the core logic of the `CALL*` family of opcodes.
+    """
+
+    gas: Uint
+    value: U256
+    caller: Address
+    to: Address
+    code_address: Address
+    should_transfer_value: bool
+    is_staticcall: bool
+    memory_input_start_position: U256
+    memory_input_size: U256
+    memory_output_start_position: U256
+    memory_output_size: U256
+    code: Bytes
+    disable_precompiles: bool
+
+
+def generic_call(evm: Evm, params: GenericCallParams) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -291,31 +299,33 @@ def generic_call(
     evm.return_data = b""
 
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
-        evm.gas_left += gas
+        evm.gas_left += params.gas
         push(evm.stack, U256(0))
         return
 
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm.memory,
+        params.memory_input_start_position,
+        params.memory_input_size,
     )
 
     child_message = Message(
         block_env=evm.message.block_env,
         tx_env=evm.message.tx_env,
-        caller=caller,
-        target=to,
-        gas=gas,
-        value=value,
+        caller=params.caller,
+        target=params.to,
+        gas=params.gas,
+        value=params.value,
         data=call_data,
-        code=code,
-        current_target=to,
+        code=params.code,
+        current_target=params.to,
         depth=evm.message.depth + Uint(1),
-        code_address=code_address,
-        should_transfer_value=should_transfer_value,
-        is_static=True if is_staticcall else evm.message.is_static,
+        code_address=params.code_address,
+        should_transfer_value=params.should_transfer_value,
+        is_static=True if params.is_staticcall else evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
-        disable_precompiles=disable_precompiles,
+        disable_precompiles=params.disable_precompiles,
         parent_evm=evm,
     )
     child_evm = process_message(child_message)
@@ -329,10 +339,12 @@ def generic_call(
         evm.return_data = child_evm.output
         push(evm.stack, U256(1))
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    actual_output_size = min(
+        params.memory_output_size, U256(len(child_evm.output))
+    )
     memory_write(
         evm.memory,
-        memory_output_start_position,
+        params.memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
 
@@ -405,19 +417,21 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
-            code,
-            disable_precompiles,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+                code=code,
+                disable_precompiles=disable_precompiles,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -490,19 +504,21 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
-            code,
-            disable_precompiles,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+                code=code,
+                disable_precompiles=disable_precompiles,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -618,19 +634,21 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        evm.message.value,
-        evm.message.caller,
-        evm.message.current_target,
-        code_address,
-        False,
-        False,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
-        code,
-        disable_precompiles,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=evm.message.value,
+            caller=evm.message.caller,
+            to=evm.message.current_target,
+            code_address=code_address,
+            should_transfer_value=False,
+            is_staticcall=False,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+            code=code,
+            disable_precompiles=disable_precompiles,
+        ),
     )
 
     # PROGRAM COUNTER
@@ -692,19 +710,21 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        U256(0),
-        evm.message.current_target,
-        to,
-        code_address,
-        True,
-        True,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
-        code,
-        disable_precompiles,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=U256(0),
+            caller=evm.message.current_target,
+            to=to,
+            code_address=code_address,
+            should_transfer_value=True,
+            is_staticcall=True,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+            code=code,
+            disable_precompiles=disable_precompiles,
+        ),
     )
 
     # PROGRAM COUNTER

--- a/src/ethereum/forks/bpo4/fork.py
+++ b/src/ethereum/forks/bpo4/fork.py
@@ -871,7 +871,7 @@ def process_transaction(
         encode_transaction(tx),
     )
 
-    intrinsic_gas, calldata_floor_gas_cost = validate_transaction(tx)
+    intrinsic = validate_transaction(tx)
 
     (
         sender,
@@ -894,7 +894,7 @@ def process_transaction(
 
     effective_gas_fee = tx.gas * effective_gas_price
 
-    gas = tx.gas - intrinsic_gas
+    gas = tx.gas - intrinsic.regular
     increment_nonce(tx_state, sender)
 
     sender_balance_after_gas_fee = (
@@ -943,7 +943,7 @@ def process_transaction(
     # Transactions with less execution_gas_used than the floor pay at the
     # floor cost.
     tx_gas_used_after_refund = max(
-        tx_gas_used_after_refund, calldata_floor_gas_cost
+        tx_gas_used_after_refund, intrinsic.calldata_floor
     )
 
     tx_gas_left = tx.gas - tx_gas_used_after_refund

--- a/src/ethereum/forks/bpo4/transactions.py
+++ b/src/ethereum/forks/bpo4/transactions.py
@@ -28,6 +28,18 @@ from .exceptions import (
 )
 from .fork_types import Authorization, VersionedHash
 
+
+@dataclass
+class IntrinsicGasCost:
+    """Intrinsic gas costs for a transaction, split by gas type."""
+
+    regular: Uint
+    """Regular execution gas (calldata, base cost, access list, etc.)."""
+
+    calldata_floor: Uint
+    """Minimum gas cost based on calldata size per [EIP-7623]."""
+
+
 TX_MAX_GAS_LIMIT = Uint(16_777_216)
 
 
@@ -506,7 +518,7 @@ def decode_transaction(tx: LegacyTransaction | Bytes) -> Transaction:
         return tx
 
 
-def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
+def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
     """
     Verifies a transaction.
 
@@ -537,8 +549,8 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     """
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
-    intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
-    if max(intrinsic_gas, calldata_floor_gas_cost) > tx.gas:
+    intrinsic = calculate_intrinsic_cost(tx)
+    if max(intrinsic.regular, intrinsic.calldata_floor) > tx.gas:
         raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
@@ -547,10 +559,10 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     if tx.gas > TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
 
-    return intrinsic_gas, calldata_floor_gas_cost
+    return intrinsic
 
 
-def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
+def calculate_intrinsic_cost(tx: Transaction) -> IntrinsicGasCost:
     """
     Calculates the gas that is charged before execution is started.
 
@@ -607,15 +619,15 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
             GasCosts.AUTH_PER_EMPTY_ACCOUNT * len(tx.authorizations)
         )
 
-    return (
-        Uint(
+    return IntrinsicGasCost(
+        regular=Uint(
             GasCosts.TX_BASE
             + data_cost
             + create_cost
             + access_list_cost
             + auth_cost
         ),
-        calldata_floor_gas_cost,
+        calldata_floor=calldata_floor_gas_cost,
     )
 
 

--- a/src/ethereum/forks/bpo4/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo4/vm/instructions/system.py
@@ -271,7 +271,7 @@ def return_(evm: Evm) -> None:
 
 
 @dataclass
-class GenericCallParams:
+class GenericCall:
     """
     Parameters for the core logic of the `CALL*` family of opcodes.
     """
@@ -291,7 +291,7 @@ class GenericCallParams:
     disable_precompiles: bool
 
 
-def generic_call(evm: Evm, params: GenericCallParams) -> None:
+def generic_call(evm: Evm, params: GenericCall) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -323,7 +323,7 @@ def generic_call(evm: Evm, params: GenericCallParams) -> None:
         depth=evm.message.depth + Uint(1),
         code_address=params.code_address,
         should_transfer_value=params.should_transfer_value,
-        is_static=True if params.is_staticcall else evm.message.is_static,
+        is_static=params.is_staticcall or evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
         disable_precompiles=params.disable_precompiles,
@@ -418,7 +418,7 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -505,7 +505,7 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -635,7 +635,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=evm.message.value,
             caller=evm.message.caller,
@@ -711,7 +711,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=U256(0),
             caller=evm.message.current_target,

--- a/src/ethereum/forks/bpo4/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo4/vm/instructions/system.py
@@ -11,6 +11,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
+from dataclasses import dataclass
+
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -268,22 +270,28 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def generic_call(
-    evm: Evm,
-    gas: Uint,
-    value: U256,
-    caller: Address,
-    to: Address,
-    code_address: Address,
-    should_transfer_value: bool,
-    is_staticcall: bool,
-    memory_input_start_position: U256,
-    memory_input_size: U256,
-    memory_output_start_position: U256,
-    memory_output_size: U256,
-    code: Bytes,
-    disable_precompiles: bool,
-) -> None:
+@dataclass
+class GenericCallParams:
+    """
+    Parameters for the core logic of the `CALL*` family of opcodes.
+    """
+
+    gas: Uint
+    value: U256
+    caller: Address
+    to: Address
+    code_address: Address
+    should_transfer_value: bool
+    is_staticcall: bool
+    memory_input_start_position: U256
+    memory_input_size: U256
+    memory_output_start_position: U256
+    memory_output_size: U256
+    code: Bytes
+    disable_precompiles: bool
+
+
+def generic_call(evm: Evm, params: GenericCallParams) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -292,31 +300,33 @@ def generic_call(
     evm.return_data = b""
 
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
-        evm.gas_left += gas
+        evm.gas_left += params.gas
         push(evm.stack, U256(0))
         return
 
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm.memory,
+        params.memory_input_start_position,
+        params.memory_input_size,
     )
 
     child_message = Message(
         block_env=evm.message.block_env,
         tx_env=evm.message.tx_env,
-        caller=caller,
-        target=to,
-        gas=gas,
-        value=value,
+        caller=params.caller,
+        target=params.to,
+        gas=params.gas,
+        value=params.value,
         data=call_data,
-        code=code,
-        current_target=to,
+        code=params.code,
+        current_target=params.to,
         depth=evm.message.depth + Uint(1),
-        code_address=code_address,
-        should_transfer_value=should_transfer_value,
-        is_static=True if is_staticcall else evm.message.is_static,
+        code_address=params.code_address,
+        should_transfer_value=params.should_transfer_value,
+        is_static=True if params.is_staticcall else evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
-        disable_precompiles=disable_precompiles,
+        disable_precompiles=params.disable_precompiles,
         parent_evm=evm,
     )
     child_evm = process_message(child_message)
@@ -330,10 +340,12 @@ def generic_call(
         evm.return_data = child_evm.output
         push(evm.stack, U256(1))
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    actual_output_size = min(
+        params.memory_output_size, U256(len(child_evm.output))
+    )
     memory_write(
         evm.memory,
-        memory_output_start_position,
+        params.memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
 
@@ -406,19 +418,21 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
-            code,
-            disable_precompiles,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+                code=code,
+                disable_precompiles=disable_precompiles,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -491,19 +505,21 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
-            code,
-            disable_precompiles,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+                code=code,
+                disable_precompiles=disable_precompiles,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -619,19 +635,21 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        evm.message.value,
-        evm.message.caller,
-        evm.message.current_target,
-        code_address,
-        False,
-        False,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
-        code,
-        disable_precompiles,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=evm.message.value,
+            caller=evm.message.caller,
+            to=evm.message.current_target,
+            code_address=code_address,
+            should_transfer_value=False,
+            is_staticcall=False,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+            code=code,
+            disable_precompiles=disable_precompiles,
+        ),
     )
 
     # PROGRAM COUNTER
@@ -693,19 +711,21 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        U256(0),
-        evm.message.current_target,
-        to,
-        code_address,
-        True,
-        True,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
-        code,
-        disable_precompiles,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=U256(0),
+            caller=evm.message.current_target,
+            to=to,
+            code_address=code_address,
+            should_transfer_value=True,
+            is_staticcall=True,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+            code=code,
+            disable_precompiles=disable_precompiles,
+        ),
     )
 
     # PROGRAM COUNTER

--- a/src/ethereum/forks/bpo4/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo4/vm/instructions/system.py
@@ -389,8 +389,8 @@ def call(evm: Evm) -> None:
         value,
         gas,
         Uint(evm.gas_left),
-        extend_memory.cost,
-        access_gas_cost + create_gas_cost + transfer_gas_cost,
+        memory_cost=extend_memory.cost,
+        extra_gas=access_gas_cost + create_gas_cost + transfer_gas_cost,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
     if evm.message.is_static and value != U256(0):

--- a/src/ethereum/forks/bpo5/fork.py
+++ b/src/ethereum/forks/bpo5/fork.py
@@ -871,7 +871,7 @@ def process_transaction(
         encode_transaction(tx),
     )
 
-    intrinsic_gas, calldata_floor_gas_cost = validate_transaction(tx)
+    intrinsic = validate_transaction(tx)
 
     (
         sender,
@@ -894,7 +894,7 @@ def process_transaction(
 
     effective_gas_fee = tx.gas * effective_gas_price
 
-    gas = tx.gas - intrinsic_gas
+    gas = tx.gas - intrinsic.regular
     increment_nonce(tx_state, sender)
 
     sender_balance_after_gas_fee = (
@@ -943,7 +943,7 @@ def process_transaction(
     # Transactions with less execution_gas_used than the floor pay at the
     # floor cost.
     tx_gas_used_after_refund = max(
-        tx_gas_used_after_refund, calldata_floor_gas_cost
+        tx_gas_used_after_refund, intrinsic.calldata_floor
     )
 
     tx_gas_left = tx.gas - tx_gas_used_after_refund

--- a/src/ethereum/forks/bpo5/transactions.py
+++ b/src/ethereum/forks/bpo5/transactions.py
@@ -28,6 +28,18 @@ from .exceptions import (
 )
 from .fork_types import Authorization, VersionedHash
 
+
+@dataclass
+class IntrinsicGasCost:
+    """Intrinsic gas costs for a transaction, split by gas type."""
+
+    regular: Uint
+    """Regular execution gas (calldata, base cost, access list, etc.)."""
+
+    calldata_floor: Uint
+    """Minimum gas cost based on calldata size per [EIP-7623]."""
+
+
 TX_MAX_GAS_LIMIT = Uint(16_777_216)
 
 
@@ -506,7 +518,7 @@ def decode_transaction(tx: LegacyTransaction | Bytes) -> Transaction:
         return tx
 
 
-def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
+def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
     """
     Verifies a transaction.
 
@@ -537,8 +549,8 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     """
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
-    intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
-    if max(intrinsic_gas, calldata_floor_gas_cost) > tx.gas:
+    intrinsic = calculate_intrinsic_cost(tx)
+    if max(intrinsic.regular, intrinsic.calldata_floor) > tx.gas:
         raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
@@ -547,10 +559,10 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     if tx.gas > TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
 
-    return intrinsic_gas, calldata_floor_gas_cost
+    return intrinsic
 
 
-def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
+def calculate_intrinsic_cost(tx: Transaction) -> IntrinsicGasCost:
     """
     Calculates the gas that is charged before execution is started.
 
@@ -607,15 +619,15 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
             GasCosts.AUTH_PER_EMPTY_ACCOUNT * len(tx.authorizations)
         )
 
-    return (
-        Uint(
+    return IntrinsicGasCost(
+        regular=Uint(
             GasCosts.TX_BASE
             + data_cost
             + create_cost
             + access_list_cost
             + auth_cost
         ),
-        calldata_floor_gas_cost,
+        calldata_floor=calldata_floor_gas_cost,
     )
 
 

--- a/src/ethereum/forks/bpo5/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo5/vm/instructions/system.py
@@ -271,7 +271,7 @@ def return_(evm: Evm) -> None:
 
 
 @dataclass
-class GenericCallParams:
+class GenericCall:
     """
     Parameters for the core logic of the `CALL*` family of opcodes.
     """
@@ -291,7 +291,7 @@ class GenericCallParams:
     disable_precompiles: bool
 
 
-def generic_call(evm: Evm, params: GenericCallParams) -> None:
+def generic_call(evm: Evm, params: GenericCall) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -323,7 +323,7 @@ def generic_call(evm: Evm, params: GenericCallParams) -> None:
         depth=evm.message.depth + Uint(1),
         code_address=params.code_address,
         should_transfer_value=params.should_transfer_value,
-        is_static=True if params.is_staticcall else evm.message.is_static,
+        is_static=params.is_staticcall or evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
         disable_precompiles=params.disable_precompiles,
@@ -418,7 +418,7 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -505,7 +505,7 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -635,7 +635,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=evm.message.value,
             caller=evm.message.caller,
@@ -711,7 +711,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=U256(0),
             caller=evm.message.current_target,

--- a/src/ethereum/forks/bpo5/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo5/vm/instructions/system.py
@@ -11,6 +11,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
+from dataclasses import dataclass
+
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -268,22 +270,28 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def generic_call(
-    evm: Evm,
-    gas: Uint,
-    value: U256,
-    caller: Address,
-    to: Address,
-    code_address: Address,
-    should_transfer_value: bool,
-    is_staticcall: bool,
-    memory_input_start_position: U256,
-    memory_input_size: U256,
-    memory_output_start_position: U256,
-    memory_output_size: U256,
-    code: Bytes,
-    disable_precompiles: bool,
-) -> None:
+@dataclass
+class GenericCallParams:
+    """
+    Parameters for the core logic of the `CALL*` family of opcodes.
+    """
+
+    gas: Uint
+    value: U256
+    caller: Address
+    to: Address
+    code_address: Address
+    should_transfer_value: bool
+    is_staticcall: bool
+    memory_input_start_position: U256
+    memory_input_size: U256
+    memory_output_start_position: U256
+    memory_output_size: U256
+    code: Bytes
+    disable_precompiles: bool
+
+
+def generic_call(evm: Evm, params: GenericCallParams) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -292,31 +300,33 @@ def generic_call(
     evm.return_data = b""
 
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
-        evm.gas_left += gas
+        evm.gas_left += params.gas
         push(evm.stack, U256(0))
         return
 
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm.memory,
+        params.memory_input_start_position,
+        params.memory_input_size,
     )
 
     child_message = Message(
         block_env=evm.message.block_env,
         tx_env=evm.message.tx_env,
-        caller=caller,
-        target=to,
-        gas=gas,
-        value=value,
+        caller=params.caller,
+        target=params.to,
+        gas=params.gas,
+        value=params.value,
         data=call_data,
-        code=code,
-        current_target=to,
+        code=params.code,
+        current_target=params.to,
         depth=evm.message.depth + Uint(1),
-        code_address=code_address,
-        should_transfer_value=should_transfer_value,
-        is_static=True if is_staticcall else evm.message.is_static,
+        code_address=params.code_address,
+        should_transfer_value=params.should_transfer_value,
+        is_static=True if params.is_staticcall else evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
-        disable_precompiles=disable_precompiles,
+        disable_precompiles=params.disable_precompiles,
         parent_evm=evm,
     )
     child_evm = process_message(child_message)
@@ -330,10 +340,12 @@ def generic_call(
         evm.return_data = child_evm.output
         push(evm.stack, U256(1))
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    actual_output_size = min(
+        params.memory_output_size, U256(len(child_evm.output))
+    )
     memory_write(
         evm.memory,
-        memory_output_start_position,
+        params.memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
 
@@ -406,19 +418,21 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
-            code,
-            disable_precompiles,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+                code=code,
+                disable_precompiles=disable_precompiles,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -491,19 +505,21 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
-            code,
-            disable_precompiles,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+                code=code,
+                disable_precompiles=disable_precompiles,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -619,19 +635,21 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        evm.message.value,
-        evm.message.caller,
-        evm.message.current_target,
-        code_address,
-        False,
-        False,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
-        code,
-        disable_precompiles,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=evm.message.value,
+            caller=evm.message.caller,
+            to=evm.message.current_target,
+            code_address=code_address,
+            should_transfer_value=False,
+            is_staticcall=False,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+            code=code,
+            disable_precompiles=disable_precompiles,
+        ),
     )
 
     # PROGRAM COUNTER
@@ -693,19 +711,21 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        U256(0),
-        evm.message.current_target,
-        to,
-        code_address,
-        True,
-        True,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
-        code,
-        disable_precompiles,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=U256(0),
+            caller=evm.message.current_target,
+            to=to,
+            code_address=code_address,
+            should_transfer_value=True,
+            is_staticcall=True,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+            code=code,
+            disable_precompiles=disable_precompiles,
+        ),
     )
 
     # PROGRAM COUNTER

--- a/src/ethereum/forks/bpo5/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo5/vm/instructions/system.py
@@ -389,8 +389,8 @@ def call(evm: Evm) -> None:
         value,
         gas,
         Uint(evm.gas_left),
-        extend_memory.cost,
-        access_gas_cost + create_gas_cost + transfer_gas_cost,
+        memory_cost=extend_memory.cost,
+        extra_gas=access_gas_cost + create_gas_cost + transfer_gas_cost,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
     if evm.message.is_static and value != U256(0):

--- a/src/ethereum/forks/byzantium/vm/instructions/system.py
+++ b/src/ethereum/forks/byzantium/vm/instructions/system.py
@@ -176,7 +176,7 @@ def return_(evm: Evm) -> None:
 
 
 @dataclass
-class GenericCallParams:
+class GenericCall:
     """
     Parameters for the core logic of the `CALL*` family of opcodes.
     """
@@ -194,7 +194,7 @@ class GenericCallParams:
     memory_output_size: U256
 
 
-def generic_call(evm: Evm, params: GenericCallParams) -> None:
+def generic_call(evm: Evm, params: GenericCall) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -227,7 +227,7 @@ def generic_call(evm: Evm, params: GenericCallParams) -> None:
         depth=evm.message.depth + Uint(1),
         code_address=params.code_address,
         should_transfer_value=params.should_transfer_value,
-        is_static=True if params.is_staticcall else evm.message.is_static,
+        is_static=params.is_staticcall or evm.message.is_static,
         parent_evm=evm,
     )
     child_evm = process_message(child_message)
@@ -308,7 +308,7 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -378,7 +378,7 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -507,7 +507,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=evm.message.value,
             caller=evm.message.caller,
@@ -568,7 +568,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=U256(0),
             caller=evm.message.current_target,

--- a/src/ethereum/forks/byzantium/vm/instructions/system.py
+++ b/src/ethereum/forks/byzantium/vm/instructions/system.py
@@ -277,8 +277,10 @@ def call(evm: Evm) -> None:
         value,
         gas,
         Uint(evm.gas_left),
-        extend_memory.cost,
-        GasCosts.OPCODE_CALL_BASE + create_gas_cost + transfer_gas_cost,
+        memory_cost=extend_memory.cost,
+        extra_gas=GasCosts.OPCODE_CALL_BASE
+        + create_gas_cost
+        + transfer_gas_cost,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
     if evm.message.is_static and value != U256(0):

--- a/src/ethereum/forks/byzantium/vm/instructions/system.py
+++ b/src/ethereum/forks/byzantium/vm/instructions/system.py
@@ -11,6 +11,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
+from dataclasses import dataclass
+
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -173,20 +175,26 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def generic_call(
-    evm: Evm,
-    gas: Uint,
-    value: U256,
-    caller: Address,
-    to: Address,
-    code_address: Address,
-    should_transfer_value: bool,
-    is_staticcall: bool,
-    memory_input_start_position: U256,
-    memory_input_size: U256,
-    memory_output_start_position: U256,
-    memory_output_size: U256,
-) -> None:
+@dataclass
+class GenericCallParams:
+    """
+    Parameters for the core logic of the `CALL*` family of opcodes.
+    """
+
+    gas: Uint
+    value: U256
+    caller: Address
+    to: Address
+    code_address: Address
+    should_transfer_value: bool
+    is_staticcall: bool
+    memory_input_start_position: U256
+    memory_input_size: U256
+    memory_output_start_position: U256
+    memory_output_size: U256
+
+
+def generic_call(evm: Evm, params: GenericCallParams) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -195,29 +203,31 @@ def generic_call(
     evm.return_data = b""
 
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
-        evm.gas_left += gas
+        evm.gas_left += params.gas
         push(evm.stack, U256(0))
         return
 
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm.memory,
+        params.memory_input_start_position,
+        params.memory_input_size,
     )
-    account = get_account(evm.message.tx_env.state, code_address)
+    account = get_account(evm.message.tx_env.state, params.code_address)
     code = get_code(evm.message.tx_env.state, account.code_hash)
     child_message = Message(
         block_env=evm.message.block_env,
         tx_env=evm.message.tx_env,
-        caller=caller,
-        target=to,
-        gas=gas,
-        value=value,
+        caller=params.caller,
+        target=params.to,
+        gas=params.gas,
+        value=params.value,
         data=call_data,
         code=code,
-        current_target=to,
+        current_target=params.to,
         depth=evm.message.depth + Uint(1),
-        code_address=code_address,
-        should_transfer_value=should_transfer_value,
-        is_static=True if is_staticcall else evm.message.is_static,
+        code_address=params.code_address,
+        should_transfer_value=params.should_transfer_value,
+        is_static=True if params.is_staticcall else evm.message.is_static,
         parent_evm=evm,
     )
     child_evm = process_message(child_message)
@@ -231,10 +241,12 @@ def generic_call(
         evm.return_data = child_evm.output
         push(evm.stack, U256(1))
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    actual_output_size = min(
+        params.memory_output_size, U256(len(child_evm.output))
+    )
     memory_write(
         evm.memory,
-        memory_output_start_position,
+        params.memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
 
@@ -296,17 +308,19 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -364,17 +378,19 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -491,17 +507,19 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        evm.message.value,
-        evm.message.caller,
-        evm.message.current_target,
-        code_address,
-        False,
-        False,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=evm.message.value,
+            caller=evm.message.caller,
+            to=evm.message.current_target,
+            code_address=code_address,
+            should_transfer_value=False,
+            is_staticcall=False,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+        ),
     )
 
     # PROGRAM COUNTER
@@ -550,17 +568,19 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        U256(0),
-        evm.message.current_target,
-        to,
-        code_address,
-        True,
-        True,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=U256(0),
+            caller=evm.message.current_target,
+            to=to,
+            code_address=code_address,
+            should_transfer_value=True,
+            is_staticcall=True,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+        ),
     )
 
     # PROGRAM COUNTER

--- a/src/ethereum/forks/cancun/vm/instructions/system.py
+++ b/src/ethereum/forks/cancun/vm/instructions/system.py
@@ -378,8 +378,8 @@ def call(evm: Evm) -> None:
         value,
         gas,
         Uint(evm.gas_left),
-        extend_memory.cost,
-        access_gas_cost + create_gas_cost + transfer_gas_cost,
+        memory_cost=extend_memory.cost,
+        extra_gas=access_gas_cost + create_gas_cost + transfer_gas_cost,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
     if evm.message.is_static and value != U256(0):

--- a/src/ethereum/forks/cancun/vm/instructions/system.py
+++ b/src/ethereum/forks/cancun/vm/instructions/system.py
@@ -269,7 +269,7 @@ def return_(evm: Evm) -> None:
 
 
 @dataclass
-class GenericCallParams:
+class GenericCall:
     """
     Parameters for the core logic of the `CALL*` family of opcodes.
     """
@@ -287,7 +287,7 @@ class GenericCallParams:
     memory_output_size: U256
 
 
-def generic_call(evm: Evm, params: GenericCallParams) -> None:
+def generic_call(evm: Evm, params: GenericCall) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -322,7 +322,7 @@ def generic_call(evm: Evm, params: GenericCallParams) -> None:
         depth=evm.message.depth + Uint(1),
         code_address=params.code_address,
         should_transfer_value=params.should_transfer_value,
-        is_static=True if params.is_staticcall else evm.message.is_static,
+        is_static=params.is_staticcall or evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
         parent_evm=evm,
@@ -409,7 +409,7 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -486,7 +486,7 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -606,7 +606,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=evm.message.value,
             caller=evm.message.caller,
@@ -673,7 +673,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=U256(0),
             caller=evm.message.current_target,

--- a/src/ethereum/forks/cancun/vm/instructions/system.py
+++ b/src/ethereum/forks/cancun/vm/instructions/system.py
@@ -11,6 +11,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
+from dataclasses import dataclass
+
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -266,20 +268,26 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def generic_call(
-    evm: Evm,
-    gas: Uint,
-    value: U256,
-    caller: Address,
-    to: Address,
-    code_address: Address,
-    should_transfer_value: bool,
-    is_staticcall: bool,
-    memory_input_start_position: U256,
-    memory_input_size: U256,
-    memory_output_start_position: U256,
-    memory_output_size: U256,
-) -> None:
+@dataclass
+class GenericCallParams:
+    """
+    Parameters for the core logic of the `CALL*` family of opcodes.
+    """
+
+    gas: Uint
+    value: U256
+    caller: Address
+    to: Address
+    code_address: Address
+    should_transfer_value: bool
+    is_staticcall: bool
+    memory_input_start_position: U256
+    memory_input_size: U256
+    memory_output_start_position: U256
+    memory_output_size: U256
+
+
+def generic_call(evm: Evm, params: GenericCallParams) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -288,29 +296,33 @@ def generic_call(
     evm.return_data = b""
 
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
-        evm.gas_left += gas
+        evm.gas_left += params.gas
         push(evm.stack, U256(0))
         return
 
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm.memory,
+        params.memory_input_start_position,
+        params.memory_input_size,
     )
     tx_state = evm.message.tx_env.state
-    code = get_code(tx_state, get_account(tx_state, code_address).code_hash)
+    code = get_code(
+        tx_state, get_account(tx_state, params.code_address).code_hash
+    )
     child_message = Message(
         block_env=evm.message.block_env,
         tx_env=evm.message.tx_env,
-        caller=caller,
-        target=to,
-        gas=gas,
-        value=value,
+        caller=params.caller,
+        target=params.to,
+        gas=params.gas,
+        value=params.value,
         data=call_data,
         code=code,
-        current_target=to,
+        current_target=params.to,
         depth=evm.message.depth + Uint(1),
-        code_address=code_address,
-        should_transfer_value=should_transfer_value,
-        is_static=True if is_staticcall else evm.message.is_static,
+        code_address=params.code_address,
+        should_transfer_value=params.should_transfer_value,
+        is_static=True if params.is_staticcall else evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
         parent_evm=evm,
@@ -326,10 +338,12 @@ def generic_call(
         evm.return_data = child_evm.output
         push(evm.stack, U256(1))
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    actual_output_size = min(
+        params.memory_output_size, U256(len(child_evm.output))
+    )
     memory_write(
         evm.memory,
-        memory_output_start_position,
+        params.memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
 
@@ -395,17 +409,19 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -470,17 +486,19 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -588,17 +606,19 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        evm.message.value,
-        evm.message.caller,
-        evm.message.current_target,
-        code_address,
-        False,
-        False,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=evm.message.value,
+            caller=evm.message.caller,
+            to=evm.message.current_target,
+            code_address=code_address,
+            should_transfer_value=False,
+            is_staticcall=False,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+        ),
     )
 
     # PROGRAM COUNTER
@@ -653,17 +673,19 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        U256(0),
-        evm.message.current_target,
-        to,
-        code_address,
-        True,
-        True,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=U256(0),
+            caller=evm.message.current_target,
+            to=to,
+            code_address=code_address,
+            should_transfer_value=True,
+            is_staticcall=True,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+        ),
     )
 
     # PROGRAM COUNTER

--- a/src/ethereum/forks/constantinople/vm/instructions/system.py
+++ b/src/ethereum/forks/constantinople/vm/instructions/system.py
@@ -249,7 +249,7 @@ def return_(evm: Evm) -> None:
 
 
 @dataclass
-class GenericCallParams:
+class GenericCall:
     """
     Parameters for the core logic of the `CALL*` family of opcodes.
     """
@@ -267,7 +267,7 @@ class GenericCallParams:
     memory_output_size: U256
 
 
-def generic_call(evm: Evm, params: GenericCallParams) -> None:
+def generic_call(evm: Evm, params: GenericCall) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -300,7 +300,7 @@ def generic_call(evm: Evm, params: GenericCallParams) -> None:
         depth=evm.message.depth + Uint(1),
         code_address=params.code_address,
         should_transfer_value=params.should_transfer_value,
-        is_static=True if params.is_staticcall else evm.message.is_static,
+        is_static=params.is_staticcall or evm.message.is_static,
         parent_evm=evm,
     )
     child_evm = process_message(child_message)
@@ -381,7 +381,7 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -451,7 +451,7 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -581,7 +581,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=evm.message.value,
             caller=evm.message.caller,
@@ -642,7 +642,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=U256(0),
             caller=evm.message.current_target,

--- a/src/ethereum/forks/constantinople/vm/instructions/system.py
+++ b/src/ethereum/forks/constantinople/vm/instructions/system.py
@@ -350,8 +350,10 @@ def call(evm: Evm) -> None:
         value,
         gas,
         Uint(evm.gas_left),
-        extend_memory.cost,
-        GasCosts.OPCODE_CALL_BASE + create_gas_cost + transfer_gas_cost,
+        memory_cost=extend_memory.cost,
+        extra_gas=GasCosts.OPCODE_CALL_BASE
+        + create_gas_cost
+        + transfer_gas_cost,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
     if evm.message.is_static and value != U256(0):

--- a/src/ethereum/forks/constantinople/vm/instructions/system.py
+++ b/src/ethereum/forks/constantinople/vm/instructions/system.py
@@ -11,6 +11,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
+from dataclasses import dataclass
+
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -246,20 +248,26 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def generic_call(
-    evm: Evm,
-    gas: Uint,
-    value: U256,
-    caller: Address,
-    to: Address,
-    code_address: Address,
-    should_transfer_value: bool,
-    is_staticcall: bool,
-    memory_input_start_position: U256,
-    memory_input_size: U256,
-    memory_output_start_position: U256,
-    memory_output_size: U256,
-) -> None:
+@dataclass
+class GenericCallParams:
+    """
+    Parameters for the core logic of the `CALL*` family of opcodes.
+    """
+
+    gas: Uint
+    value: U256
+    caller: Address
+    to: Address
+    code_address: Address
+    should_transfer_value: bool
+    is_staticcall: bool
+    memory_input_start_position: U256
+    memory_input_size: U256
+    memory_output_start_position: U256
+    memory_output_size: U256
+
+
+def generic_call(evm: Evm, params: GenericCallParams) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -268,29 +276,31 @@ def generic_call(
     evm.return_data = b""
 
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
-        evm.gas_left += gas
+        evm.gas_left += params.gas
         push(evm.stack, U256(0))
         return
 
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm.memory,
+        params.memory_input_start_position,
+        params.memory_input_size,
     )
-    account = get_account(evm.message.tx_env.state, code_address)
+    account = get_account(evm.message.tx_env.state, params.code_address)
     code = get_code(evm.message.tx_env.state, account.code_hash)
     child_message = Message(
         block_env=evm.message.block_env,
         tx_env=evm.message.tx_env,
-        caller=caller,
-        target=to,
-        gas=gas,
-        value=value,
+        caller=params.caller,
+        target=params.to,
+        gas=params.gas,
+        value=params.value,
         data=call_data,
         code=code,
-        current_target=to,
+        current_target=params.to,
         depth=evm.message.depth + Uint(1),
-        code_address=code_address,
-        should_transfer_value=should_transfer_value,
-        is_static=True if is_staticcall else evm.message.is_static,
+        code_address=params.code_address,
+        should_transfer_value=params.should_transfer_value,
+        is_static=True if params.is_staticcall else evm.message.is_static,
         parent_evm=evm,
     )
     child_evm = process_message(child_message)
@@ -304,10 +314,12 @@ def generic_call(
         evm.return_data = child_evm.output
         push(evm.stack, U256(1))
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    actual_output_size = min(
+        params.memory_output_size, U256(len(child_evm.output))
+    )
     memory_write(
         evm.memory,
-        memory_output_start_position,
+        params.memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
 
@@ -369,17 +381,19 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -437,17 +451,19 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -565,17 +581,19 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        evm.message.value,
-        evm.message.caller,
-        evm.message.current_target,
-        code_address,
-        False,
-        False,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=evm.message.value,
+            caller=evm.message.caller,
+            to=evm.message.current_target,
+            code_address=code_address,
+            should_transfer_value=False,
+            is_staticcall=False,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+        ),
     )
 
     # PROGRAM COUNTER
@@ -624,17 +642,19 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        U256(0),
-        evm.message.current_target,
-        to,
-        code_address,
-        True,
-        True,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=U256(0),
+            caller=evm.message.current_target,
+            to=to,
+            code_address=code_address,
+            should_transfer_value=True,
+            is_staticcall=True,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+        ),
     )
 
     # PROGRAM COUNTER

--- a/src/ethereum/forks/dao_fork/vm/instructions/system.py
+++ b/src/ethereum/forks/dao_fork/vm/instructions/system.py
@@ -167,7 +167,7 @@ def return_(evm: Evm) -> None:
 
 
 @dataclass
-class GenericCallParams:
+class GenericCall:
     """
     Parameters for the core logic of the `CALL*` family of opcodes.
     """
@@ -184,7 +184,7 @@ class GenericCallParams:
     memory_output_size: U256
 
 
-def generic_call(evm: Evm, params: GenericCallParams) -> None:
+def generic_call(evm: Evm, params: GenericCall) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -284,7 +284,7 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -347,7 +347,7 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -455,7 +455,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=gas,
             value=evm.message.value,
             caller=evm.message.caller,

--- a/src/ethereum/forks/dao_fork/vm/instructions/system.py
+++ b/src/ethereum/forks/dao_fork/vm/instructions/system.py
@@ -11,6 +11,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
+from dataclasses import dataclass
+
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -164,47 +166,57 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def generic_call(
-    evm: Evm,
-    gas: Uint,
-    value: U256,
-    caller: Address,
-    to: Address,
-    code_address: Address,
-    should_transfer_value: bool,
-    memory_input_start_position: U256,
-    memory_input_size: U256,
-    memory_output_start_position: U256,
-    memory_output_size: U256,
-) -> None:
+@dataclass
+class GenericCallParams:
+    """
+    Parameters for the core logic of the `CALL*` family of opcodes.
+    """
+
+    gas: Uint
+    value: U256
+    caller: Address
+    to: Address
+    code_address: Address
+    should_transfer_value: bool
+    memory_input_start_position: U256
+    memory_input_size: U256
+    memory_output_start_position: U256
+    memory_output_size: U256
+
+
+def generic_call(evm: Evm, params: GenericCallParams) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
 
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
-        evm.gas_left += gas
+        evm.gas_left += params.gas
         push(evm.stack, U256(0))
         return
 
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm.memory,
+        params.memory_input_start_position,
+        params.memory_input_size,
     )
-    account_to_call = get_account(evm.message.tx_env.state, code_address)
+    account_to_call = get_account(
+        evm.message.tx_env.state, params.code_address
+    )
     code = get_code(evm.message.tx_env.state, account_to_call.code_hash)
     child_message = Message(
         block_env=evm.message.block_env,
         tx_env=evm.message.tx_env,
-        caller=caller,
-        target=to,
-        gas=gas,
-        value=value,
+        caller=params.caller,
+        target=params.to,
+        gas=params.gas,
+        value=params.value,
         data=call_data,
         code=code,
-        current_target=to,
+        current_target=params.to,
         depth=evm.message.depth + Uint(1),
-        code_address=code_address,
-        should_transfer_value=should_transfer_value,
+        code_address=params.code_address,
+        should_transfer_value=params.should_transfer_value,
         parent_evm=evm,
     )
     child_evm = process_message(child_message)
@@ -216,10 +228,12 @@ def generic_call(
         incorporate_child_on_success(evm, child_evm)
         push(evm.stack, U256(1))
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    actual_output_size = min(
+        params.memory_output_size, U256(len(child_evm.output))
+    )
     memory_write(
         evm.memory,
-        memory_output_start_position,
+        params.memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
 
@@ -270,16 +284,18 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -331,16 +347,18 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -437,16 +455,18 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        gas,
-        evm.message.value,
-        evm.message.caller,
-        evm.message.current_target,
-        code_address,
-        False,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
+        GenericCallParams(
+            gas=gas,
+            value=evm.message.value,
+            caller=evm.message.caller,
+            to=evm.message.current_target,
+            code_address=code_address,
+            should_transfer_value=False,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+        ),
     )
 
     # PROGRAM COUNTER

--- a/src/ethereum/forks/frontier/vm/instructions/system.py
+++ b/src/ethereum/forks/frontier/vm/instructions/system.py
@@ -11,6 +11,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
+from dataclasses import dataclass
+
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -163,45 +165,55 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def generic_call(
-    evm: Evm,
-    gas: Uint,
-    value: U256,
-    caller: Address,
-    to: Address,
-    code_address: Address,
-    memory_input_start_position: U256,
-    memory_input_size: U256,
-    memory_output_start_position: U256,
-    memory_output_size: U256,
-) -> None:
+@dataclass
+class GenericCallParams:
+    """
+    Parameters for the core logic of the `CALL*` family of opcodes.
+    """
+
+    gas: Uint
+    value: U256
+    caller: Address
+    to: Address
+    code_address: Address
+    memory_input_start_position: U256
+    memory_input_size: U256
+    memory_output_start_position: U256
+    memory_output_size: U256
+
+
+def generic_call(evm: Evm, params: GenericCallParams) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
 
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
-        evm.gas_left += gas
+        evm.gas_left += params.gas
         push(evm.stack, U256(0))
         return
 
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm.memory,
+        params.memory_input_start_position,
+        params.memory_input_size,
     )
-    account_to_call = get_account(evm.message.tx_env.state, code_address)
+    account_to_call = get_account(
+        evm.message.tx_env.state, params.code_address
+    )
     code = get_code(evm.message.tx_env.state, account_to_call.code_hash)
     child_message = Message(
         block_env=evm.message.block_env,
         tx_env=evm.message.tx_env,
-        caller=caller,
-        target=to,
-        gas=gas,
-        value=value,
+        caller=params.caller,
+        target=params.to,
+        gas=params.gas,
+        value=params.value,
         data=call_data,
         code=code,
-        current_target=to,
+        current_target=params.to,
         depth=evm.message.depth + Uint(1),
-        code_address=code_address,
+        code_address=params.code_address,
         parent_evm=evm,
     )
     child_evm = process_message(child_message)
@@ -213,10 +225,12 @@ def generic_call(
         incorporate_child_on_success(evm, child_evm)
         push(evm.stack, U256(1))
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    actual_output_size = min(
+        params.memory_output_size, U256(len(child_evm.output))
+    )
     memory_write(
         evm.memory,
-        memory_output_start_position,
+        params.memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
 
@@ -267,15 +281,17 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -327,15 +343,17 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER

--- a/src/ethereum/forks/frontier/vm/instructions/system.py
+++ b/src/ethereum/forks/frontier/vm/instructions/system.py
@@ -166,7 +166,7 @@ def return_(evm: Evm) -> None:
 
 
 @dataclass
-class GenericCallParams:
+class GenericCall:
     """
     Parameters for the core logic of the `CALL*` family of opcodes.
     """
@@ -182,7 +182,7 @@ class GenericCallParams:
     memory_output_size: U256
 
 
-def generic_call(evm: Evm, params: GenericCallParams) -> None:
+def generic_call(evm: Evm, params: GenericCall) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -281,7 +281,7 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -343,7 +343,7 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,

--- a/src/ethereum/forks/gray_glacier/vm/instructions/system.py
+++ b/src/ethereum/forks/gray_glacier/vm/instructions/system.py
@@ -249,7 +249,7 @@ def return_(evm: Evm) -> None:
 
 
 @dataclass
-class GenericCallParams:
+class GenericCall:
     """
     Parameters for the core logic of the `CALL*` family of opcodes.
     """
@@ -267,7 +267,7 @@ class GenericCallParams:
     memory_output_size: U256
 
 
-def generic_call(evm: Evm, params: GenericCallParams) -> None:
+def generic_call(evm: Evm, params: GenericCall) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -300,7 +300,7 @@ def generic_call(evm: Evm, params: GenericCallParams) -> None:
         depth=evm.message.depth + Uint(1),
         code_address=params.code_address,
         should_transfer_value=params.should_transfer_value,
-        is_static=True if params.is_staticcall else evm.message.is_static,
+        is_static=params.is_staticcall or evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
         parent_evm=evm,
@@ -387,7 +387,7 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -464,7 +464,7 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -590,7 +590,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=evm.message.value,
             caller=evm.message.caller,
@@ -657,7 +657,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=U256(0),
             caller=evm.message.current_target,

--- a/src/ethereum/forks/gray_glacier/vm/instructions/system.py
+++ b/src/ethereum/forks/gray_glacier/vm/instructions/system.py
@@ -358,8 +358,8 @@ def call(evm: Evm) -> None:
         value,
         gas,
         Uint(evm.gas_left),
-        extend_memory.cost,
-        access_gas_cost + create_gas_cost + transfer_gas_cost,
+        memory_cost=extend_memory.cost,
+        extra_gas=access_gas_cost + create_gas_cost + transfer_gas_cost,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
     if evm.message.is_static and value != U256(0):

--- a/src/ethereum/forks/gray_glacier/vm/instructions/system.py
+++ b/src/ethereum/forks/gray_glacier/vm/instructions/system.py
@@ -11,6 +11,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
+from dataclasses import dataclass
+
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -246,20 +248,26 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def generic_call(
-    evm: Evm,
-    gas: Uint,
-    value: U256,
-    caller: Address,
-    to: Address,
-    code_address: Address,
-    should_transfer_value: bool,
-    is_staticcall: bool,
-    memory_input_start_position: U256,
-    memory_input_size: U256,
-    memory_output_start_position: U256,
-    memory_output_size: U256,
-) -> None:
+@dataclass
+class GenericCallParams:
+    """
+    Parameters for the core logic of the `CALL*` family of opcodes.
+    """
+
+    gas: Uint
+    value: U256
+    caller: Address
+    to: Address
+    code_address: Address
+    should_transfer_value: bool
+    is_staticcall: bool
+    memory_input_start_position: U256
+    memory_input_size: U256
+    memory_output_start_position: U256
+    memory_output_size: U256
+
+
+def generic_call(evm: Evm, params: GenericCallParams) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -268,29 +276,31 @@ def generic_call(
     evm.return_data = b""
 
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
-        evm.gas_left += gas
+        evm.gas_left += params.gas
         push(evm.stack, U256(0))
         return
 
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm.memory,
+        params.memory_input_start_position,
+        params.memory_input_size,
     )
-    account = get_account(evm.message.tx_env.state, code_address)
+    account = get_account(evm.message.tx_env.state, params.code_address)
     code = get_code(evm.message.tx_env.state, account.code_hash)
     child_message = Message(
         block_env=evm.message.block_env,
         tx_env=evm.message.tx_env,
-        caller=caller,
-        target=to,
-        gas=gas,
-        value=value,
+        caller=params.caller,
+        target=params.to,
+        gas=params.gas,
+        value=params.value,
         data=call_data,
         code=code,
-        current_target=to,
+        current_target=params.to,
         depth=evm.message.depth + Uint(1),
-        code_address=code_address,
-        should_transfer_value=should_transfer_value,
-        is_static=True if is_staticcall else evm.message.is_static,
+        code_address=params.code_address,
+        should_transfer_value=params.should_transfer_value,
+        is_static=True if params.is_staticcall else evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
         parent_evm=evm,
@@ -306,10 +316,12 @@ def generic_call(
         evm.return_data = child_evm.output
         push(evm.stack, U256(1))
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    actual_output_size = min(
+        params.memory_output_size, U256(len(child_evm.output))
+    )
     memory_write(
         evm.memory,
-        memory_output_start_position,
+        params.memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
 
@@ -375,17 +387,19 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -450,17 +464,19 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -574,17 +590,19 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        evm.message.value,
-        evm.message.caller,
-        evm.message.current_target,
-        code_address,
-        False,
-        False,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=evm.message.value,
+            caller=evm.message.caller,
+            to=evm.message.current_target,
+            code_address=code_address,
+            should_transfer_value=False,
+            is_staticcall=False,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+        ),
     )
 
     # PROGRAM COUNTER
@@ -639,17 +657,19 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        U256(0),
-        evm.message.current_target,
-        to,
-        code_address,
-        True,
-        True,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=U256(0),
+            caller=evm.message.current_target,
+            to=to,
+            code_address=code_address,
+            should_transfer_value=True,
+            is_staticcall=True,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+        ),
     )
 
     # PROGRAM COUNTER

--- a/src/ethereum/forks/homestead/vm/instructions/system.py
+++ b/src/ethereum/forks/homestead/vm/instructions/system.py
@@ -167,7 +167,7 @@ def return_(evm: Evm) -> None:
 
 
 @dataclass
-class GenericCallParams:
+class GenericCall:
     """
     Parameters for the core logic of the `CALL*` family of opcodes.
     """
@@ -184,7 +184,7 @@ class GenericCallParams:
     memory_output_size: U256
 
 
-def generic_call(evm: Evm, params: GenericCallParams) -> None:
+def generic_call(evm: Evm, params: GenericCall) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -284,7 +284,7 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -347,7 +347,7 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -455,7 +455,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=gas,
             value=evm.message.value,
             caller=evm.message.caller,

--- a/src/ethereum/forks/homestead/vm/instructions/system.py
+++ b/src/ethereum/forks/homestead/vm/instructions/system.py
@@ -11,6 +11,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
+from dataclasses import dataclass
+
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -164,47 +166,57 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def generic_call(
-    evm: Evm,
-    gas: Uint,
-    value: U256,
-    caller: Address,
-    to: Address,
-    code_address: Address,
-    should_transfer_value: bool,
-    memory_input_start_position: U256,
-    memory_input_size: U256,
-    memory_output_start_position: U256,
-    memory_output_size: U256,
-) -> None:
+@dataclass
+class GenericCallParams:
+    """
+    Parameters for the core logic of the `CALL*` family of opcodes.
+    """
+
+    gas: Uint
+    value: U256
+    caller: Address
+    to: Address
+    code_address: Address
+    should_transfer_value: bool
+    memory_input_start_position: U256
+    memory_input_size: U256
+    memory_output_start_position: U256
+    memory_output_size: U256
+
+
+def generic_call(evm: Evm, params: GenericCallParams) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
 
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
-        evm.gas_left += gas
+        evm.gas_left += params.gas
         push(evm.stack, U256(0))
         return
 
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm.memory,
+        params.memory_input_start_position,
+        params.memory_input_size,
     )
-    account_to_call = get_account(evm.message.tx_env.state, code_address)
+    account_to_call = get_account(
+        evm.message.tx_env.state, params.code_address
+    )
     code = get_code(evm.message.tx_env.state, account_to_call.code_hash)
     child_message = Message(
         block_env=evm.message.block_env,
         tx_env=evm.message.tx_env,
-        caller=caller,
-        target=to,
-        gas=gas,
-        value=value,
+        caller=params.caller,
+        target=params.to,
+        gas=params.gas,
+        value=params.value,
         data=call_data,
         code=code,
-        current_target=to,
+        current_target=params.to,
         depth=evm.message.depth + Uint(1),
-        code_address=code_address,
-        should_transfer_value=should_transfer_value,
+        code_address=params.code_address,
+        should_transfer_value=params.should_transfer_value,
         parent_evm=evm,
     )
     child_evm = process_message(child_message)
@@ -216,10 +228,12 @@ def generic_call(
         incorporate_child_on_success(evm, child_evm)
         push(evm.stack, U256(1))
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    actual_output_size = min(
+        params.memory_output_size, U256(len(child_evm.output))
+    )
     memory_write(
         evm.memory,
-        memory_output_start_position,
+        params.memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
 
@@ -270,16 +284,18 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -331,16 +347,18 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -437,16 +455,18 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        gas,
-        evm.message.value,
-        evm.message.caller,
-        evm.message.current_target,
-        code_address,
-        False,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
+        GenericCallParams(
+            gas=gas,
+            value=evm.message.value,
+            caller=evm.message.caller,
+            to=evm.message.current_target,
+            code_address=code_address,
+            should_transfer_value=False,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+        ),
     )
 
     # PROGRAM COUNTER

--- a/src/ethereum/forks/istanbul/vm/instructions/system.py
+++ b/src/ethereum/forks/istanbul/vm/instructions/system.py
@@ -11,6 +11,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
+from dataclasses import dataclass
+
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -246,20 +248,26 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def generic_call(
-    evm: Evm,
-    gas: Uint,
-    value: U256,
-    caller: Address,
-    to: Address,
-    code_address: Address,
-    should_transfer_value: bool,
-    is_staticcall: bool,
-    memory_input_start_position: U256,
-    memory_input_size: U256,
-    memory_output_start_position: U256,
-    memory_output_size: U256,
-) -> None:
+@dataclass
+class GenericCallParams:
+    """
+    Parameters for the core logic of the `CALL*` family of opcodes.
+    """
+
+    gas: Uint
+    value: U256
+    caller: Address
+    to: Address
+    code_address: Address
+    should_transfer_value: bool
+    is_staticcall: bool
+    memory_input_start_position: U256
+    memory_input_size: U256
+    memory_output_start_position: U256
+    memory_output_size: U256
+
+
+def generic_call(evm: Evm, params: GenericCallParams) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -268,29 +276,31 @@ def generic_call(
     evm.return_data = b""
 
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
-        evm.gas_left += gas
+        evm.gas_left += params.gas
         push(evm.stack, U256(0))
         return
 
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm.memory,
+        params.memory_input_start_position,
+        params.memory_input_size,
     )
-    code_account = get_account(evm.message.tx_env.state, code_address)
+    code_account = get_account(evm.message.tx_env.state, params.code_address)
     code = get_code(evm.message.tx_env.state, code_account.code_hash)
     child_message = Message(
         block_env=evm.message.block_env,
         tx_env=evm.message.tx_env,
-        caller=caller,
-        target=to,
-        gas=gas,
-        value=value,
+        caller=params.caller,
+        target=params.to,
+        gas=params.gas,
+        value=params.value,
         data=call_data,
         code=code,
-        current_target=to,
+        current_target=params.to,
         depth=evm.message.depth + Uint(1),
-        code_address=code_address,
-        should_transfer_value=should_transfer_value,
-        is_static=True if is_staticcall else evm.message.is_static,
+        code_address=params.code_address,
+        should_transfer_value=params.should_transfer_value,
+        is_static=True if params.is_staticcall else evm.message.is_static,
         parent_evm=evm,
     )
     child_evm = process_message(child_message)
@@ -304,10 +314,12 @@ def generic_call(
         evm.return_data = child_evm.output
         push(evm.stack, U256(1))
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    actual_output_size = min(
+        params.memory_output_size, U256(len(child_evm.output))
+    )
     memory_write(
         evm.memory,
-        memory_output_start_position,
+        params.memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
 
@@ -369,17 +381,19 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -437,17 +451,19 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -565,17 +581,19 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        evm.message.value,
-        evm.message.caller,
-        evm.message.current_target,
-        code_address,
-        False,
-        False,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=evm.message.value,
+            caller=evm.message.caller,
+            to=evm.message.current_target,
+            code_address=code_address,
+            should_transfer_value=False,
+            is_staticcall=False,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+        ),
     )
 
     # PROGRAM COUNTER
@@ -624,17 +642,19 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        U256(0),
-        evm.message.current_target,
-        to,
-        code_address,
-        True,
-        True,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=U256(0),
+            caller=evm.message.current_target,
+            to=to,
+            code_address=code_address,
+            should_transfer_value=True,
+            is_staticcall=True,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+        ),
     )
 
     # PROGRAM COUNTER

--- a/src/ethereum/forks/istanbul/vm/instructions/system.py
+++ b/src/ethereum/forks/istanbul/vm/instructions/system.py
@@ -249,7 +249,7 @@ def return_(evm: Evm) -> None:
 
 
 @dataclass
-class GenericCallParams:
+class GenericCall:
     """
     Parameters for the core logic of the `CALL*` family of opcodes.
     """
@@ -267,7 +267,7 @@ class GenericCallParams:
     memory_output_size: U256
 
 
-def generic_call(evm: Evm, params: GenericCallParams) -> None:
+def generic_call(evm: Evm, params: GenericCall) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -300,7 +300,7 @@ def generic_call(evm: Evm, params: GenericCallParams) -> None:
         depth=evm.message.depth + Uint(1),
         code_address=params.code_address,
         should_transfer_value=params.should_transfer_value,
-        is_static=True if params.is_staticcall else evm.message.is_static,
+        is_static=params.is_staticcall or evm.message.is_static,
         parent_evm=evm,
     )
     child_evm = process_message(child_message)
@@ -381,7 +381,7 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -451,7 +451,7 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -581,7 +581,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=evm.message.value,
             caller=evm.message.caller,
@@ -642,7 +642,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=U256(0),
             caller=evm.message.current_target,

--- a/src/ethereum/forks/istanbul/vm/instructions/system.py
+++ b/src/ethereum/forks/istanbul/vm/instructions/system.py
@@ -350,8 +350,10 @@ def call(evm: Evm) -> None:
         value,
         gas,
         Uint(evm.gas_left),
-        extend_memory.cost,
-        GasCosts.OPCODE_CALL_BASE + create_gas_cost + transfer_gas_cost,
+        memory_cost=extend_memory.cost,
+        extra_gas=GasCosts.OPCODE_CALL_BASE
+        + create_gas_cost
+        + transfer_gas_cost,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
     if evm.message.is_static and value != U256(0):

--- a/src/ethereum/forks/london/vm/instructions/system.py
+++ b/src/ethereum/forks/london/vm/instructions/system.py
@@ -249,7 +249,7 @@ def return_(evm: Evm) -> None:
 
 
 @dataclass
-class GenericCallParams:
+class GenericCall:
     """
     Parameters for the core logic of the `CALL*` family of opcodes.
     """
@@ -267,7 +267,7 @@ class GenericCallParams:
     memory_output_size: U256
 
 
-def generic_call(evm: Evm, params: GenericCallParams) -> None:
+def generic_call(evm: Evm, params: GenericCall) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -300,7 +300,7 @@ def generic_call(evm: Evm, params: GenericCallParams) -> None:
         depth=evm.message.depth + Uint(1),
         code_address=params.code_address,
         should_transfer_value=params.should_transfer_value,
-        is_static=True if params.is_staticcall else evm.message.is_static,
+        is_static=params.is_staticcall or evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
         parent_evm=evm,
@@ -387,7 +387,7 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -464,7 +464,7 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -590,7 +590,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=evm.message.value,
             caller=evm.message.caller,
@@ -657,7 +657,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=U256(0),
             caller=evm.message.current_target,

--- a/src/ethereum/forks/london/vm/instructions/system.py
+++ b/src/ethereum/forks/london/vm/instructions/system.py
@@ -358,8 +358,8 @@ def call(evm: Evm) -> None:
         value,
         gas,
         Uint(evm.gas_left),
-        extend_memory.cost,
-        access_gas_cost + create_gas_cost + transfer_gas_cost,
+        memory_cost=extend_memory.cost,
+        extra_gas=access_gas_cost + create_gas_cost + transfer_gas_cost,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
     if evm.message.is_static and value != U256(0):

--- a/src/ethereum/forks/london/vm/instructions/system.py
+++ b/src/ethereum/forks/london/vm/instructions/system.py
@@ -11,6 +11,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
+from dataclasses import dataclass
+
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -246,20 +248,26 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def generic_call(
-    evm: Evm,
-    gas: Uint,
-    value: U256,
-    caller: Address,
-    to: Address,
-    code_address: Address,
-    should_transfer_value: bool,
-    is_staticcall: bool,
-    memory_input_start_position: U256,
-    memory_input_size: U256,
-    memory_output_start_position: U256,
-    memory_output_size: U256,
-) -> None:
+@dataclass
+class GenericCallParams:
+    """
+    Parameters for the core logic of the `CALL*` family of opcodes.
+    """
+
+    gas: Uint
+    value: U256
+    caller: Address
+    to: Address
+    code_address: Address
+    should_transfer_value: bool
+    is_staticcall: bool
+    memory_input_start_position: U256
+    memory_input_size: U256
+    memory_output_start_position: U256
+    memory_output_size: U256
+
+
+def generic_call(evm: Evm, params: GenericCallParams) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -268,29 +276,31 @@ def generic_call(
     evm.return_data = b""
 
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
-        evm.gas_left += gas
+        evm.gas_left += params.gas
         push(evm.stack, U256(0))
         return
 
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm.memory,
+        params.memory_input_start_position,
+        params.memory_input_size,
     )
-    account = get_account(evm.message.tx_env.state, code_address)
+    account = get_account(evm.message.tx_env.state, params.code_address)
     code = get_code(evm.message.tx_env.state, account.code_hash)
     child_message = Message(
         block_env=evm.message.block_env,
         tx_env=evm.message.tx_env,
-        caller=caller,
-        target=to,
-        gas=gas,
-        value=value,
+        caller=params.caller,
+        target=params.to,
+        gas=params.gas,
+        value=params.value,
         data=call_data,
         code=code,
-        current_target=to,
+        current_target=params.to,
         depth=evm.message.depth + Uint(1),
-        code_address=code_address,
-        should_transfer_value=should_transfer_value,
-        is_static=True if is_staticcall else evm.message.is_static,
+        code_address=params.code_address,
+        should_transfer_value=params.should_transfer_value,
+        is_static=True if params.is_staticcall else evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
         parent_evm=evm,
@@ -306,10 +316,12 @@ def generic_call(
         evm.return_data = child_evm.output
         push(evm.stack, U256(1))
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    actual_output_size = min(
+        params.memory_output_size, U256(len(child_evm.output))
+    )
     memory_write(
         evm.memory,
-        memory_output_start_position,
+        params.memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
 
@@ -375,17 +387,19 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -450,17 +464,19 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -574,17 +590,19 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        evm.message.value,
-        evm.message.caller,
-        evm.message.current_target,
-        code_address,
-        False,
-        False,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=evm.message.value,
+            caller=evm.message.caller,
+            to=evm.message.current_target,
+            code_address=code_address,
+            should_transfer_value=False,
+            is_staticcall=False,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+        ),
     )
 
     # PROGRAM COUNTER
@@ -639,17 +657,19 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        U256(0),
-        evm.message.current_target,
-        to,
-        code_address,
-        True,
-        True,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=U256(0),
+            caller=evm.message.current_target,
+            to=to,
+            code_address=code_address,
+            should_transfer_value=True,
+            is_staticcall=True,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+        ),
     )
 
     # PROGRAM COUNTER

--- a/src/ethereum/forks/muir_glacier/vm/instructions/system.py
+++ b/src/ethereum/forks/muir_glacier/vm/instructions/system.py
@@ -11,6 +11,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
+from dataclasses import dataclass
+
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -246,20 +248,26 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def generic_call(
-    evm: Evm,
-    gas: Uint,
-    value: U256,
-    caller: Address,
-    to: Address,
-    code_address: Address,
-    should_transfer_value: bool,
-    is_staticcall: bool,
-    memory_input_start_position: U256,
-    memory_input_size: U256,
-    memory_output_start_position: U256,
-    memory_output_size: U256,
-) -> None:
+@dataclass
+class GenericCallParams:
+    """
+    Parameters for the core logic of the `CALL*` family of opcodes.
+    """
+
+    gas: Uint
+    value: U256
+    caller: Address
+    to: Address
+    code_address: Address
+    should_transfer_value: bool
+    is_staticcall: bool
+    memory_input_start_position: U256
+    memory_input_size: U256
+    memory_output_start_position: U256
+    memory_output_size: U256
+
+
+def generic_call(evm: Evm, params: GenericCallParams) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -268,29 +276,31 @@ def generic_call(
     evm.return_data = b""
 
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
-        evm.gas_left += gas
+        evm.gas_left += params.gas
         push(evm.stack, U256(0))
         return
 
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm.memory,
+        params.memory_input_start_position,
+        params.memory_input_size,
     )
-    code_account = get_account(evm.message.tx_env.state, code_address)
+    code_account = get_account(evm.message.tx_env.state, params.code_address)
     code = get_code(evm.message.tx_env.state, code_account.code_hash)
     child_message = Message(
         block_env=evm.message.block_env,
         tx_env=evm.message.tx_env,
-        caller=caller,
-        target=to,
-        gas=gas,
-        value=value,
+        caller=params.caller,
+        target=params.to,
+        gas=params.gas,
+        value=params.value,
         data=call_data,
         code=code,
-        current_target=to,
+        current_target=params.to,
         depth=evm.message.depth + Uint(1),
-        code_address=code_address,
-        should_transfer_value=should_transfer_value,
-        is_static=True if is_staticcall else evm.message.is_static,
+        code_address=params.code_address,
+        should_transfer_value=params.should_transfer_value,
+        is_static=True if params.is_staticcall else evm.message.is_static,
         parent_evm=evm,
     )
     child_evm = process_message(child_message)
@@ -304,10 +314,12 @@ def generic_call(
         evm.return_data = child_evm.output
         push(evm.stack, U256(1))
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    actual_output_size = min(
+        params.memory_output_size, U256(len(child_evm.output))
+    )
     memory_write(
         evm.memory,
-        memory_output_start_position,
+        params.memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
 
@@ -369,17 +381,19 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -437,17 +451,19 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -565,17 +581,19 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        evm.message.value,
-        evm.message.caller,
-        evm.message.current_target,
-        code_address,
-        False,
-        False,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=evm.message.value,
+            caller=evm.message.caller,
+            to=evm.message.current_target,
+            code_address=code_address,
+            should_transfer_value=False,
+            is_staticcall=False,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+        ),
     )
 
     # PROGRAM COUNTER
@@ -624,17 +642,19 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        U256(0),
-        evm.message.current_target,
-        to,
-        code_address,
-        True,
-        True,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=U256(0),
+            caller=evm.message.current_target,
+            to=to,
+            code_address=code_address,
+            should_transfer_value=True,
+            is_staticcall=True,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+        ),
     )
 
     # PROGRAM COUNTER

--- a/src/ethereum/forks/muir_glacier/vm/instructions/system.py
+++ b/src/ethereum/forks/muir_glacier/vm/instructions/system.py
@@ -249,7 +249,7 @@ def return_(evm: Evm) -> None:
 
 
 @dataclass
-class GenericCallParams:
+class GenericCall:
     """
     Parameters for the core logic of the `CALL*` family of opcodes.
     """
@@ -267,7 +267,7 @@ class GenericCallParams:
     memory_output_size: U256
 
 
-def generic_call(evm: Evm, params: GenericCallParams) -> None:
+def generic_call(evm: Evm, params: GenericCall) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -300,7 +300,7 @@ def generic_call(evm: Evm, params: GenericCallParams) -> None:
         depth=evm.message.depth + Uint(1),
         code_address=params.code_address,
         should_transfer_value=params.should_transfer_value,
-        is_static=True if params.is_staticcall else evm.message.is_static,
+        is_static=params.is_staticcall or evm.message.is_static,
         parent_evm=evm,
     )
     child_evm = process_message(child_message)
@@ -381,7 +381,7 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -451,7 +451,7 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -581,7 +581,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=evm.message.value,
             caller=evm.message.caller,
@@ -642,7 +642,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=U256(0),
             caller=evm.message.current_target,

--- a/src/ethereum/forks/muir_glacier/vm/instructions/system.py
+++ b/src/ethereum/forks/muir_glacier/vm/instructions/system.py
@@ -350,8 +350,10 @@ def call(evm: Evm) -> None:
         value,
         gas,
         Uint(evm.gas_left),
-        extend_memory.cost,
-        GasCosts.OPCODE_CALL_BASE + create_gas_cost + transfer_gas_cost,
+        memory_cost=extend_memory.cost,
+        extra_gas=GasCosts.OPCODE_CALL_BASE
+        + create_gas_cost
+        + transfer_gas_cost,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
     if evm.message.is_static and value != U256(0):

--- a/src/ethereum/forks/osaka/fork.py
+++ b/src/ethereum/forks/osaka/fork.py
@@ -871,7 +871,7 @@ def process_transaction(
         encode_transaction(tx),
     )
 
-    intrinsic_gas, calldata_floor_gas_cost = validate_transaction(tx)
+    intrinsic = validate_transaction(tx)
 
     (
         sender,
@@ -894,7 +894,7 @@ def process_transaction(
 
     effective_gas_fee = tx.gas * effective_gas_price
 
-    gas = tx.gas - intrinsic_gas
+    gas = tx.gas - intrinsic.regular
     increment_nonce(tx_state, sender)
 
     sender_balance_after_gas_fee = (
@@ -943,7 +943,7 @@ def process_transaction(
     # Transactions with less execution_gas_used than the floor pay at the
     # floor cost.
     tx_gas_used_after_refund = max(
-        tx_gas_used_after_refund, calldata_floor_gas_cost
+        tx_gas_used_after_refund, intrinsic.calldata_floor
     )
 
     tx_gas_left = tx.gas - tx_gas_used_after_refund

--- a/src/ethereum/forks/osaka/transactions.py
+++ b/src/ethereum/forks/osaka/transactions.py
@@ -28,6 +28,18 @@ from .exceptions import (
 )
 from .fork_types import Authorization, VersionedHash
 
+
+@dataclass
+class IntrinsicGasCost:
+    """Intrinsic gas costs for a transaction, split by gas type."""
+
+    regular: Uint
+    """Regular execution gas (calldata, base cost, access list, etc.)."""
+
+    calldata_floor: Uint
+    """Minimum gas cost based on calldata size per [EIP-7623]."""
+
+
 TX_MAX_GAS_LIMIT = Uint(16_777_216)
 
 
@@ -506,7 +518,7 @@ def decode_transaction(tx: LegacyTransaction | Bytes) -> Transaction:
         return tx
 
 
-def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
+def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
     """
     Verifies a transaction.
 
@@ -537,8 +549,8 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     """
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
-    intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
-    if max(intrinsic_gas, calldata_floor_gas_cost) > tx.gas:
+    intrinsic = calculate_intrinsic_cost(tx)
+    if max(intrinsic.regular, intrinsic.calldata_floor) > tx.gas:
         raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
@@ -547,10 +559,10 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     if tx.gas > TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
 
-    return intrinsic_gas, calldata_floor_gas_cost
+    return intrinsic
 
 
-def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
+def calculate_intrinsic_cost(tx: Transaction) -> IntrinsicGasCost:
     """
     Calculates the gas that is charged before execution is started.
 
@@ -607,15 +619,15 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
             GasCosts.AUTH_PER_EMPTY_ACCOUNT * len(tx.authorizations)
         )
 
-    return (
-        Uint(
+    return IntrinsicGasCost(
+        regular=Uint(
             GasCosts.TX_BASE
             + data_cost
             + create_cost
             + access_list_cost
             + auth_cost
         ),
-        calldata_floor_gas_cost,
+        calldata_floor=calldata_floor_gas_cost,
     )
 
 

--- a/src/ethereum/forks/osaka/vm/instructions/system.py
+++ b/src/ethereum/forks/osaka/vm/instructions/system.py
@@ -271,7 +271,7 @@ def return_(evm: Evm) -> None:
 
 
 @dataclass
-class GenericCallParams:
+class GenericCall:
     """
     Parameters for the core logic of the `CALL*` family of opcodes.
     """
@@ -291,7 +291,7 @@ class GenericCallParams:
     disable_precompiles: bool
 
 
-def generic_call(evm: Evm, params: GenericCallParams) -> None:
+def generic_call(evm: Evm, params: GenericCall) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -323,7 +323,7 @@ def generic_call(evm: Evm, params: GenericCallParams) -> None:
         depth=evm.message.depth + Uint(1),
         code_address=params.code_address,
         should_transfer_value=params.should_transfer_value,
-        is_static=True if params.is_staticcall else evm.message.is_static,
+        is_static=params.is_staticcall or evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
         disable_precompiles=params.disable_precompiles,
@@ -418,7 +418,7 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -506,7 +506,7 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -641,7 +641,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=evm.message.value,
             caller=evm.message.caller,
@@ -717,7 +717,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=U256(0),
             caller=evm.message.current_target,

--- a/src/ethereum/forks/osaka/vm/instructions/system.py
+++ b/src/ethereum/forks/osaka/vm/instructions/system.py
@@ -389,8 +389,8 @@ def call(evm: Evm) -> None:
         value,
         gas,
         Uint(evm.gas_left),
-        extend_memory.cost,
-        access_gas_cost + create_gas_cost + transfer_gas_cost,
+        memory_cost=extend_memory.cost,
+        extra_gas=access_gas_cost + create_gas_cost + transfer_gas_cost,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
     if evm.message.is_static and value != U256(0):

--- a/src/ethereum/forks/osaka/vm/instructions/system.py
+++ b/src/ethereum/forks/osaka/vm/instructions/system.py
@@ -11,6 +11,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
+from dataclasses import dataclass
+
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -268,22 +270,28 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def generic_call(
-    evm: Evm,
-    gas: Uint,
-    value: U256,
-    caller: Address,
-    to: Address,
-    code_address: Address,
-    should_transfer_value: bool,
-    is_staticcall: bool,
-    memory_input_start_position: U256,
-    memory_input_size: U256,
-    memory_output_start_position: U256,
-    memory_output_size: U256,
-    code: Bytes,
-    disable_precompiles: bool,
-) -> None:
+@dataclass
+class GenericCallParams:
+    """
+    Parameters for the core logic of the `CALL*` family of opcodes.
+    """
+
+    gas: Uint
+    value: U256
+    caller: Address
+    to: Address
+    code_address: Address
+    should_transfer_value: bool
+    is_staticcall: bool
+    memory_input_start_position: U256
+    memory_input_size: U256
+    memory_output_start_position: U256
+    memory_output_size: U256
+    code: Bytes
+    disable_precompiles: bool
+
+
+def generic_call(evm: Evm, params: GenericCallParams) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -292,31 +300,33 @@ def generic_call(
     evm.return_data = b""
 
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
-        evm.gas_left += gas
+        evm.gas_left += params.gas
         push(evm.stack, U256(0))
         return
 
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm.memory,
+        params.memory_input_start_position,
+        params.memory_input_size,
     )
 
     child_message = Message(
         block_env=evm.message.block_env,
         tx_env=evm.message.tx_env,
-        caller=caller,
-        target=to,
-        gas=gas,
-        value=value,
+        caller=params.caller,
+        target=params.to,
+        gas=params.gas,
+        value=params.value,
         data=call_data,
-        code=code,
-        current_target=to,
+        code=params.code,
+        current_target=params.to,
         depth=evm.message.depth + Uint(1),
-        code_address=code_address,
-        should_transfer_value=should_transfer_value,
-        is_static=True if is_staticcall else evm.message.is_static,
+        code_address=params.code_address,
+        should_transfer_value=params.should_transfer_value,
+        is_static=True if params.is_staticcall else evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
-        disable_precompiles=disable_precompiles,
+        disable_precompiles=params.disable_precompiles,
         parent_evm=evm,
     )
     child_evm = process_message(child_message)
@@ -330,10 +340,12 @@ def generic_call(
         evm.return_data = child_evm.output
         push(evm.stack, U256(1))
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    actual_output_size = min(
+        params.memory_output_size, U256(len(child_evm.output))
+    )
     memory_write(
         evm.memory,
-        memory_output_start_position,
+        params.memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
 
@@ -406,19 +418,21 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
-            code,
-            disable_precompiles,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+                code=code,
+                disable_precompiles=disable_precompiles,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -492,19 +506,21 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
-            code,
-            disable_precompiles,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+                code=code,
+                disable_precompiles=disable_precompiles,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -625,19 +641,21 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        evm.message.value,
-        evm.message.caller,
-        evm.message.current_target,
-        code_address,
-        False,
-        False,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
-        code,
-        disable_precompiles,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=evm.message.value,
+            caller=evm.message.caller,
+            to=evm.message.current_target,
+            code_address=code_address,
+            should_transfer_value=False,
+            is_staticcall=False,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+            code=code,
+            disable_precompiles=disable_precompiles,
+        ),
     )
 
     # PROGRAM COUNTER
@@ -699,19 +717,21 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        U256(0),
-        evm.message.current_target,
-        to,
-        code_address,
-        True,
-        True,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
-        code,
-        disable_precompiles,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=U256(0),
+            caller=evm.message.current_target,
+            to=to,
+            code_address=code_address,
+            should_transfer_value=True,
+            is_staticcall=True,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+            code=code,
+            disable_precompiles=disable_precompiles,
+        ),
     )
 
     # PROGRAM COUNTER

--- a/src/ethereum/forks/paris/vm/instructions/system.py
+++ b/src/ethereum/forks/paris/vm/instructions/system.py
@@ -248,7 +248,7 @@ def return_(evm: Evm) -> None:
 
 
 @dataclass
-class GenericCallParams:
+class GenericCall:
     """
     Parameters for the core logic of the `CALL*` family of opcodes.
     """
@@ -266,7 +266,7 @@ class GenericCallParams:
     memory_output_size: U256
 
 
-def generic_call(evm: Evm, params: GenericCallParams) -> None:
+def generic_call(evm: Evm, params: GenericCall) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -301,7 +301,7 @@ def generic_call(evm: Evm, params: GenericCallParams) -> None:
         depth=evm.message.depth + Uint(1),
         code_address=params.code_address,
         should_transfer_value=params.should_transfer_value,
-        is_static=True if params.is_staticcall else evm.message.is_static,
+        is_static=params.is_staticcall or evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
         parent_evm=evm,
@@ -388,7 +388,7 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -465,7 +465,7 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -587,7 +587,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=evm.message.value,
             caller=evm.message.caller,
@@ -654,7 +654,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=U256(0),
             caller=evm.message.current_target,

--- a/src/ethereum/forks/paris/vm/instructions/system.py
+++ b/src/ethereum/forks/paris/vm/instructions/system.py
@@ -11,6 +11,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
+from dataclasses import dataclass
+
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -245,20 +247,26 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def generic_call(
-    evm: Evm,
-    gas: Uint,
-    value: U256,
-    caller: Address,
-    to: Address,
-    code_address: Address,
-    should_transfer_value: bool,
-    is_staticcall: bool,
-    memory_input_start_position: U256,
-    memory_input_size: U256,
-    memory_output_start_position: U256,
-    memory_output_size: U256,
-) -> None:
+@dataclass
+class GenericCallParams:
+    """
+    Parameters for the core logic of the `CALL*` family of opcodes.
+    """
+
+    gas: Uint
+    value: U256
+    caller: Address
+    to: Address
+    code_address: Address
+    should_transfer_value: bool
+    is_staticcall: bool
+    memory_input_start_position: U256
+    memory_input_size: U256
+    memory_output_start_position: U256
+    memory_output_size: U256
+
+
+def generic_call(evm: Evm, params: GenericCallParams) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -267,29 +275,33 @@ def generic_call(
     evm.return_data = b""
 
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
-        evm.gas_left += gas
+        evm.gas_left += params.gas
         push(evm.stack, U256(0))
         return
 
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm.memory,
+        params.memory_input_start_position,
+        params.memory_input_size,
     )
     tx_state = evm.message.tx_env.state
-    code = get_code(tx_state, get_account(tx_state, code_address).code_hash)
+    code = get_code(
+        tx_state, get_account(tx_state, params.code_address).code_hash
+    )
     child_message = Message(
         block_env=evm.message.block_env,
         tx_env=evm.message.tx_env,
-        caller=caller,
-        target=to,
-        gas=gas,
-        value=value,
+        caller=params.caller,
+        target=params.to,
+        gas=params.gas,
+        value=params.value,
         data=call_data,
         code=code,
-        current_target=to,
+        current_target=params.to,
         depth=evm.message.depth + Uint(1),
-        code_address=code_address,
-        should_transfer_value=should_transfer_value,
-        is_static=True if is_staticcall else evm.message.is_static,
+        code_address=params.code_address,
+        should_transfer_value=params.should_transfer_value,
+        is_static=True if params.is_staticcall else evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
         parent_evm=evm,
@@ -305,10 +317,12 @@ def generic_call(
         evm.return_data = child_evm.output
         push(evm.stack, U256(1))
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    actual_output_size = min(
+        params.memory_output_size, U256(len(child_evm.output))
+    )
     memory_write(
         evm.memory,
-        memory_output_start_position,
+        params.memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
 
@@ -374,17 +388,19 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -449,17 +465,19 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -569,17 +587,19 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        evm.message.value,
-        evm.message.caller,
-        evm.message.current_target,
-        code_address,
-        False,
-        False,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=evm.message.value,
+            caller=evm.message.caller,
+            to=evm.message.current_target,
+            code_address=code_address,
+            should_transfer_value=False,
+            is_staticcall=False,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+        ),
     )
 
     # PROGRAM COUNTER
@@ -634,17 +654,19 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        U256(0),
-        evm.message.current_target,
-        to,
-        code_address,
-        True,
-        True,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=U256(0),
+            caller=evm.message.current_target,
+            to=to,
+            code_address=code_address,
+            should_transfer_value=True,
+            is_staticcall=True,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+        ),
     )
 
     # PROGRAM COUNTER

--- a/src/ethereum/forks/paris/vm/instructions/system.py
+++ b/src/ethereum/forks/paris/vm/instructions/system.py
@@ -357,8 +357,8 @@ def call(evm: Evm) -> None:
         value,
         gas,
         Uint(evm.gas_left),
-        extend_memory.cost,
-        access_gas_cost + create_gas_cost + transfer_gas_cost,
+        memory_cost=extend_memory.cost,
+        extra_gas=access_gas_cost + create_gas_cost + transfer_gas_cost,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
     if evm.message.is_static and value != U256(0):

--- a/src/ethereum/forks/prague/fork.py
+++ b/src/ethereum/forks/prague/fork.py
@@ -854,7 +854,7 @@ def process_transaction(
         encode_transaction(tx),
     )
 
-    intrinsic_gas, calldata_floor_gas_cost = validate_transaction(tx)
+    intrinsic = validate_transaction(tx)
 
     (
         sender,
@@ -877,7 +877,7 @@ def process_transaction(
 
     effective_gas_fee = tx.gas * effective_gas_price
 
-    gas = tx.gas - intrinsic_gas
+    gas = tx.gas - intrinsic.regular
     increment_nonce(tx_state, sender)
 
     sender_balance_after_gas_fee = (
@@ -926,7 +926,7 @@ def process_transaction(
     # Transactions with less execution_gas_used than the floor pay at the
     # floor cost.
     tx_gas_used_after_refund = max(
-        tx_gas_used_after_refund, calldata_floor_gas_cost
+        tx_gas_used_after_refund, intrinsic.calldata_floor
     )
 
     tx_gas_left = tx.gas - tx_gas_used_after_refund

--- a/src/ethereum/forks/prague/transactions.py
+++ b/src/ethereum/forks/prague/transactions.py
@@ -25,6 +25,17 @@ from .exceptions import InitCodeTooLargeError, TransactionTypeError
 from .fork_types import Authorization, VersionedHash
 
 
+@dataclass
+class IntrinsicGasCost:
+    """Intrinsic gas costs for a transaction, split by gas type."""
+
+    regular: Uint
+    """Regular execution gas (calldata, base cost, access list, etc.)."""
+
+    calldata_floor: Uint
+    """Minimum gas cost based on calldata size per [EIP-7623]."""
+
+
 @slotted_freezable
 @dataclass
 class LegacyTransaction:
@@ -500,7 +511,7 @@ def decode_transaction(tx: LegacyTransaction | Bytes) -> Transaction:
         return tx
 
 
-def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
+def validate_transaction(tx: Transaction) -> IntrinsicGasCost:
     """
     Verifies a transaction.
 
@@ -531,18 +542,18 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     """
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
-    intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
-    if max(intrinsic_gas, calldata_floor_gas_cost) > tx.gas:
+    intrinsic = calculate_intrinsic_cost(tx)
+    if max(intrinsic.regular, intrinsic.calldata_floor) > tx.gas:
         raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
     if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
         raise InitCodeTooLargeError("Code size too large")
 
-    return intrinsic_gas, calldata_floor_gas_cost
+    return intrinsic
 
 
-def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
+def calculate_intrinsic_cost(tx: Transaction) -> IntrinsicGasCost:
     """
     Calculates the gas that is charged before execution is started.
 
@@ -599,15 +610,15 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
             GasCosts.AUTH_PER_EMPTY_ACCOUNT * len(tx.authorizations)
         )
 
-    return (
-        Uint(
+    return IntrinsicGasCost(
+        regular=Uint(
             GasCosts.TX_BASE
             + data_cost
             + create_cost
             + access_list_cost
             + auth_cost
         ),
-        calldata_floor_gas_cost,
+        calldata_floor=calldata_floor_gas_cost,
     )
 
 

--- a/src/ethereum/forks/prague/vm/instructions/system.py
+++ b/src/ethereum/forks/prague/vm/instructions/system.py
@@ -270,7 +270,7 @@ def return_(evm: Evm) -> None:
 
 
 @dataclass
-class GenericCallParams:
+class GenericCall:
     """
     Parameters for the core logic of the `CALL*` family of opcodes.
     """
@@ -290,7 +290,7 @@ class GenericCallParams:
     disable_precompiles: bool
 
 
-def generic_call(evm: Evm, params: GenericCallParams) -> None:
+def generic_call(evm: Evm, params: GenericCall) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -322,7 +322,7 @@ def generic_call(evm: Evm, params: GenericCallParams) -> None:
         depth=evm.message.depth + Uint(1),
         code_address=params.code_address,
         should_transfer_value=params.should_transfer_value,
-        is_static=True if params.is_staticcall else evm.message.is_static,
+        is_static=params.is_staticcall or evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
         disable_precompiles=params.disable_precompiles,
@@ -417,7 +417,7 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -504,7 +504,7 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -634,7 +634,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=evm.message.value,
             caller=evm.message.caller,
@@ -710,7 +710,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=U256(0),
             caller=evm.message.current_target,

--- a/src/ethereum/forks/prague/vm/instructions/system.py
+++ b/src/ethereum/forks/prague/vm/instructions/system.py
@@ -388,8 +388,8 @@ def call(evm: Evm) -> None:
         value,
         gas,
         Uint(evm.gas_left),
-        extend_memory.cost,
-        access_gas_cost + create_gas_cost + transfer_gas_cost,
+        memory_cost=extend_memory.cost,
+        extra_gas=access_gas_cost + create_gas_cost + transfer_gas_cost,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
     if evm.message.is_static and value != U256(0):

--- a/src/ethereum/forks/prague/vm/instructions/system.py
+++ b/src/ethereum/forks/prague/vm/instructions/system.py
@@ -11,6 +11,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
+from dataclasses import dataclass
+
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -267,22 +269,28 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def generic_call(
-    evm: Evm,
-    gas: Uint,
-    value: U256,
-    caller: Address,
-    to: Address,
-    code_address: Address,
-    should_transfer_value: bool,
-    is_staticcall: bool,
-    memory_input_start_position: U256,
-    memory_input_size: U256,
-    memory_output_start_position: U256,
-    memory_output_size: U256,
-    code: Bytes,
-    disable_precompiles: bool,
-) -> None:
+@dataclass
+class GenericCallParams:
+    """
+    Parameters for the core logic of the `CALL*` family of opcodes.
+    """
+
+    gas: Uint
+    value: U256
+    caller: Address
+    to: Address
+    code_address: Address
+    should_transfer_value: bool
+    is_staticcall: bool
+    memory_input_start_position: U256
+    memory_input_size: U256
+    memory_output_start_position: U256
+    memory_output_size: U256
+    code: Bytes
+    disable_precompiles: bool
+
+
+def generic_call(evm: Evm, params: GenericCallParams) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -291,31 +299,33 @@ def generic_call(
     evm.return_data = b""
 
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
-        evm.gas_left += gas
+        evm.gas_left += params.gas
         push(evm.stack, U256(0))
         return
 
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm.memory,
+        params.memory_input_start_position,
+        params.memory_input_size,
     )
 
     child_message = Message(
         block_env=evm.message.block_env,
         tx_env=evm.message.tx_env,
-        caller=caller,
-        target=to,
-        gas=gas,
-        value=value,
+        caller=params.caller,
+        target=params.to,
+        gas=params.gas,
+        value=params.value,
         data=call_data,
-        code=code,
-        current_target=to,
+        code=params.code,
+        current_target=params.to,
         depth=evm.message.depth + Uint(1),
-        code_address=code_address,
-        should_transfer_value=should_transfer_value,
-        is_static=True if is_staticcall else evm.message.is_static,
+        code_address=params.code_address,
+        should_transfer_value=params.should_transfer_value,
+        is_static=True if params.is_staticcall else evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
-        disable_precompiles=disable_precompiles,
+        disable_precompiles=params.disable_precompiles,
         parent_evm=evm,
     )
     child_evm = process_message(child_message)
@@ -329,10 +339,12 @@ def generic_call(
         evm.return_data = child_evm.output
         push(evm.stack, U256(1))
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    actual_output_size = min(
+        params.memory_output_size, U256(len(child_evm.output))
+    )
     memory_write(
         evm.memory,
-        memory_output_start_position,
+        params.memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
 
@@ -405,19 +417,21 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
-            code,
-            disable_precompiles,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+                code=code,
+                disable_precompiles=disable_precompiles,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -490,19 +504,21 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
-            code,
-            disable_precompiles,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+                code=code,
+                disable_precompiles=disable_precompiles,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -618,19 +634,21 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        evm.message.value,
-        evm.message.caller,
-        evm.message.current_target,
-        code_address,
-        False,
-        False,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
-        code,
-        disable_precompiles,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=evm.message.value,
+            caller=evm.message.caller,
+            to=evm.message.current_target,
+            code_address=code_address,
+            should_transfer_value=False,
+            is_staticcall=False,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+            code=code,
+            disable_precompiles=disable_precompiles,
+        ),
     )
 
     # PROGRAM COUNTER
@@ -692,19 +710,21 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        U256(0),
-        evm.message.current_target,
-        to,
-        code_address,
-        True,
-        True,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
-        code,
-        disable_precompiles,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=U256(0),
+            caller=evm.message.current_target,
+            to=to,
+            code_address=code_address,
+            should_transfer_value=True,
+            is_staticcall=True,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+            code=code,
+            disable_precompiles=disable_precompiles,
+        ),
     )
 
     # PROGRAM COUNTER

--- a/src/ethereum/forks/shanghai/vm/instructions/system.py
+++ b/src/ethereum/forks/shanghai/vm/instructions/system.py
@@ -377,8 +377,8 @@ def call(evm: Evm) -> None:
         value,
         gas,
         Uint(evm.gas_left),
-        extend_memory.cost,
-        access_gas_cost + create_gas_cost + transfer_gas_cost,
+        memory_cost=extend_memory.cost,
+        extra_gas=access_gas_cost + create_gas_cost + transfer_gas_cost,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
     if evm.message.is_static and value != U256(0):

--- a/src/ethereum/forks/shanghai/vm/instructions/system.py
+++ b/src/ethereum/forks/shanghai/vm/instructions/system.py
@@ -268,7 +268,7 @@ def return_(evm: Evm) -> None:
 
 
 @dataclass
-class GenericCallParams:
+class GenericCall:
     """
     Parameters for the core logic of the `CALL*` family of opcodes.
     """
@@ -286,7 +286,7 @@ class GenericCallParams:
     memory_output_size: U256
 
 
-def generic_call(evm: Evm, params: GenericCallParams) -> None:
+def generic_call(evm: Evm, params: GenericCall) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -321,7 +321,7 @@ def generic_call(evm: Evm, params: GenericCallParams) -> None:
         depth=evm.message.depth + Uint(1),
         code_address=params.code_address,
         should_transfer_value=params.should_transfer_value,
-        is_static=True if params.is_staticcall else evm.message.is_static,
+        is_static=params.is_staticcall or evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
         parent_evm=evm,
@@ -408,7 +408,7 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -485,7 +485,7 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -607,7 +607,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=evm.message.value,
             caller=evm.message.caller,
@@ -674,7 +674,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=U256(0),
             caller=evm.message.current_target,

--- a/src/ethereum/forks/shanghai/vm/instructions/system.py
+++ b/src/ethereum/forks/shanghai/vm/instructions/system.py
@@ -11,6 +11,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
+from dataclasses import dataclass
+
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -265,20 +267,26 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def generic_call(
-    evm: Evm,
-    gas: Uint,
-    value: U256,
-    caller: Address,
-    to: Address,
-    code_address: Address,
-    should_transfer_value: bool,
-    is_staticcall: bool,
-    memory_input_start_position: U256,
-    memory_input_size: U256,
-    memory_output_start_position: U256,
-    memory_output_size: U256,
-) -> None:
+@dataclass
+class GenericCallParams:
+    """
+    Parameters for the core logic of the `CALL*` family of opcodes.
+    """
+
+    gas: Uint
+    value: U256
+    caller: Address
+    to: Address
+    code_address: Address
+    should_transfer_value: bool
+    is_staticcall: bool
+    memory_input_start_position: U256
+    memory_input_size: U256
+    memory_output_start_position: U256
+    memory_output_size: U256
+
+
+def generic_call(evm: Evm, params: GenericCallParams) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -287,29 +295,33 @@ def generic_call(
     evm.return_data = b""
 
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
-        evm.gas_left += gas
+        evm.gas_left += params.gas
         push(evm.stack, U256(0))
         return
 
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm.memory,
+        params.memory_input_start_position,
+        params.memory_input_size,
     )
     tx_state = evm.message.tx_env.state
-    code = get_code(tx_state, get_account(tx_state, code_address).code_hash)
+    code = get_code(
+        tx_state, get_account(tx_state, params.code_address).code_hash
+    )
     child_message = Message(
         block_env=evm.message.block_env,
         tx_env=evm.message.tx_env,
-        caller=caller,
-        target=to,
-        gas=gas,
-        value=value,
+        caller=params.caller,
+        target=params.to,
+        gas=params.gas,
+        value=params.value,
         data=call_data,
         code=code,
-        current_target=to,
+        current_target=params.to,
         depth=evm.message.depth + Uint(1),
-        code_address=code_address,
-        should_transfer_value=should_transfer_value,
-        is_static=True if is_staticcall else evm.message.is_static,
+        code_address=params.code_address,
+        should_transfer_value=params.should_transfer_value,
+        is_static=True if params.is_staticcall else evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
         parent_evm=evm,
@@ -325,10 +337,12 @@ def generic_call(
         evm.return_data = child_evm.output
         push(evm.stack, U256(1))
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    actual_output_size = min(
+        params.memory_output_size, U256(len(child_evm.output))
+    )
     memory_write(
         evm.memory,
-        memory_output_start_position,
+        params.memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
 
@@ -394,17 +408,19 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -469,17 +485,19 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            False,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                is_staticcall=False,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -589,17 +607,19 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        evm.message.value,
-        evm.message.caller,
-        evm.message.current_target,
-        code_address,
-        False,
-        False,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=evm.message.value,
+            caller=evm.message.caller,
+            to=evm.message.current_target,
+            code_address=code_address,
+            should_transfer_value=False,
+            is_staticcall=False,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+        ),
     )
 
     # PROGRAM COUNTER
@@ -654,17 +674,19 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        U256(0),
-        evm.message.current_target,
-        to,
-        code_address,
-        True,
-        True,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=U256(0),
+            caller=evm.message.current_target,
+            to=to,
+            code_address=code_address,
+            should_transfer_value=True,
+            is_staticcall=True,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+        ),
     )
 
     # PROGRAM COUNTER

--- a/src/ethereum/forks/spurious_dragon/vm/instructions/system.py
+++ b/src/ethereum/forks/spurious_dragon/vm/instructions/system.py
@@ -170,7 +170,7 @@ def return_(evm: Evm) -> None:
 
 
 @dataclass
-class GenericCallParams:
+class GenericCall:
     """
     Parameters for the core logic of the `CALL*` family of opcodes.
     """
@@ -187,7 +187,7 @@ class GenericCallParams:
     memory_output_size: U256
 
 
-def generic_call(evm: Evm, params: GenericCallParams) -> None:
+def generic_call(evm: Evm, params: GenericCall) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -295,7 +295,7 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -363,7 +363,7 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -489,7 +489,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=evm.message.value,
             caller=evm.message.caller,

--- a/src/ethereum/forks/spurious_dragon/vm/instructions/system.py
+++ b/src/ethereum/forks/spurious_dragon/vm/instructions/system.py
@@ -11,6 +11,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
+from dataclasses import dataclass
+
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -167,47 +169,55 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def generic_call(
-    evm: Evm,
-    gas: Uint,
-    value: U256,
-    caller: Address,
-    to: Address,
-    code_address: Address,
-    should_transfer_value: bool,
-    memory_input_start_position: U256,
-    memory_input_size: U256,
-    memory_output_start_position: U256,
-    memory_output_size: U256,
-) -> None:
+@dataclass
+class GenericCallParams:
+    """
+    Parameters for the core logic of the `CALL*` family of opcodes.
+    """
+
+    gas: Uint
+    value: U256
+    caller: Address
+    to: Address
+    code_address: Address
+    should_transfer_value: bool
+    memory_input_start_position: U256
+    memory_input_size: U256
+    memory_output_start_position: U256
+    memory_output_size: U256
+
+
+def generic_call(evm: Evm, params: GenericCallParams) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
 
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
-        evm.gas_left += gas
+        evm.gas_left += params.gas
         push(evm.stack, U256(0))
         return
 
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm.memory,
+        params.memory_input_start_position,
+        params.memory_input_size,
     )
-    account = get_account(evm.message.tx_env.state, code_address)
+    account = get_account(evm.message.tx_env.state, params.code_address)
     code = get_code(evm.message.tx_env.state, account.code_hash)
     child_message = Message(
         block_env=evm.message.block_env,
         tx_env=evm.message.tx_env,
-        caller=caller,
-        target=to,
-        gas=gas,
-        value=value,
+        caller=params.caller,
+        target=params.to,
+        gas=params.gas,
+        value=params.value,
         data=call_data,
         code=code,
-        current_target=to,
+        current_target=params.to,
         depth=evm.message.depth + Uint(1),
-        code_address=code_address,
-        should_transfer_value=should_transfer_value,
+        code_address=params.code_address,
+        should_transfer_value=params.should_transfer_value,
         parent_evm=evm,
     )
     child_evm = process_message(child_message)
@@ -219,10 +229,12 @@ def generic_call(
         incorporate_child_on_success(evm, child_evm)
         push(evm.stack, U256(1))
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    actual_output_size = min(
+        params.memory_output_size, U256(len(child_evm.output))
+    )
     memory_write(
         evm.memory,
-        memory_output_start_position,
+        params.memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
 
@@ -283,16 +295,18 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -349,16 +363,18 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -473,16 +489,18 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        evm.message.value,
-        evm.message.caller,
-        evm.message.current_target,
-        code_address,
-        False,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=evm.message.value,
+            caller=evm.message.caller,
+            to=evm.message.current_target,
+            code_address=code_address,
+            should_transfer_value=False,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+        ),
     )
 
     # PROGRAM COUNTER

--- a/src/ethereum/forks/spurious_dragon/vm/instructions/system.py
+++ b/src/ethereum/forks/spurious_dragon/vm/instructions/system.py
@@ -265,8 +265,10 @@ def call(evm: Evm) -> None:
         value,
         gas,
         Uint(evm.gas_left),
-        extend_memory.cost,
-        GasCosts.OPCODE_CALL_BASE + create_gas_cost + transfer_gas_cost,
+        memory_cost=extend_memory.cost,
+        extra_gas=GasCosts.OPCODE_CALL_BASE
+        + create_gas_cost
+        + transfer_gas_cost,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 

--- a/src/ethereum/forks/tangerine_whistle/vm/instructions/system.py
+++ b/src/ethereum/forks/tangerine_whistle/vm/instructions/system.py
@@ -263,8 +263,10 @@ def call(evm: Evm) -> None:
         value,
         gas,
         Uint(evm.gas_left),
-        extend_memory.cost,
-        GasCosts.OPCODE_CALL_BASE + create_gas_cost + transfer_gas_cost,
+        memory_cost=extend_memory.cost,
+        extra_gas=GasCosts.OPCODE_CALL_BASE
+        + create_gas_cost
+        + transfer_gas_cost,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 

--- a/src/ethereum/forks/tangerine_whistle/vm/instructions/system.py
+++ b/src/ethereum/forks/tangerine_whistle/vm/instructions/system.py
@@ -11,6 +11,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
+from dataclasses import dataclass
+
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -166,47 +168,55 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def generic_call(
-    evm: Evm,
-    gas: Uint,
-    value: U256,
-    caller: Address,
-    to: Address,
-    code_address: Address,
-    should_transfer_value: bool,
-    memory_input_start_position: U256,
-    memory_input_size: U256,
-    memory_output_start_position: U256,
-    memory_output_size: U256,
-) -> None:
+@dataclass
+class GenericCallParams:
+    """
+    Parameters for the core logic of the `CALL*` family of opcodes.
+    """
+
+    gas: Uint
+    value: U256
+    caller: Address
+    to: Address
+    code_address: Address
+    should_transfer_value: bool
+    memory_input_start_position: U256
+    memory_input_size: U256
+    memory_output_start_position: U256
+    memory_output_size: U256
+
+
+def generic_call(evm: Evm, params: GenericCallParams) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
 
     if evm.message.depth + Uint(1) > STACK_DEPTH_LIMIT:
-        evm.gas_left += gas
+        evm.gas_left += params.gas
         push(evm.stack, U256(0))
         return
 
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm.memory,
+        params.memory_input_start_position,
+        params.memory_input_size,
     )
-    account = get_account(evm.message.tx_env.state, code_address)
+    account = get_account(evm.message.tx_env.state, params.code_address)
     code = get_code(evm.message.tx_env.state, account.code_hash)
     child_message = Message(
         block_env=evm.message.block_env,
         tx_env=evm.message.tx_env,
-        caller=caller,
-        target=to,
-        gas=gas,
-        value=value,
+        caller=params.caller,
+        target=params.to,
+        gas=params.gas,
+        value=params.value,
         data=call_data,
         code=code,
-        current_target=to,
+        current_target=params.to,
         depth=evm.message.depth + Uint(1),
-        code_address=code_address,
-        should_transfer_value=should_transfer_value,
+        code_address=params.code_address,
+        should_transfer_value=params.should_transfer_value,
         parent_evm=evm,
     )
     child_evm = process_message(child_message)
@@ -218,10 +228,12 @@ def generic_call(
         incorporate_child_on_success(evm, child_evm)
         push(evm.stack, U256(1))
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    actual_output_size = min(
+        params.memory_output_size, U256(len(child_evm.output))
+    )
     memory_write(
         evm.memory,
-        memory_output_start_position,
+        params.memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
 
@@ -281,16 +293,18 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -347,16 +361,18 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            message_call_gas.sub_call,
-            value,
-            evm.message.current_target,
-            to,
-            code_address,
-            True,
-            memory_input_start_position,
-            memory_input_size,
-            memory_output_start_position,
-            memory_output_size,
+            GenericCallParams(
+                gas=message_call_gas.sub_call,
+                value=value,
+                caller=evm.message.current_target,
+                to=to,
+                code_address=code_address,
+                should_transfer_value=True,
+                memory_input_start_position=memory_input_start_position,
+                memory_input_size=memory_input_size,
+                memory_output_start_position=memory_output_start_position,
+                memory_output_size=memory_output_size,
+            ),
         )
 
     # PROGRAM COUNTER
@@ -462,16 +478,18 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.sub_call,
-        evm.message.value,
-        evm.message.caller,
-        evm.message.current_target,
-        code_address,
-        False,
-        memory_input_start_position,
-        memory_input_size,
-        memory_output_start_position,
-        memory_output_size,
+        GenericCallParams(
+            gas=message_call_gas.sub_call,
+            value=evm.message.value,
+            caller=evm.message.caller,
+            to=evm.message.current_target,
+            code_address=code_address,
+            should_transfer_value=False,
+            memory_input_start_position=memory_input_start_position,
+            memory_input_size=memory_input_size,
+            memory_output_start_position=memory_output_start_position,
+            memory_output_size=memory_output_size,
+        ),
     )
 
     # PROGRAM COUNTER

--- a/src/ethereum/forks/tangerine_whistle/vm/instructions/system.py
+++ b/src/ethereum/forks/tangerine_whistle/vm/instructions/system.py
@@ -169,7 +169,7 @@ def return_(evm: Evm) -> None:
 
 
 @dataclass
-class GenericCallParams:
+class GenericCall:
     """
     Parameters for the core logic of the `CALL*` family of opcodes.
     """
@@ -186,7 +186,7 @@ class GenericCallParams:
     memory_output_size: U256
 
 
-def generic_call(evm: Evm, params: GenericCallParams) -> None:
+def generic_call(evm: Evm, params: GenericCall) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
     """
@@ -293,7 +293,7 @@ def call(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -361,7 +361,7 @@ def callcode(evm: Evm) -> None:
     else:
         generic_call(
             evm,
-            GenericCallParams(
+            GenericCall(
                 gas=message_call_gas.sub_call,
                 value=value,
                 caller=evm.message.current_target,
@@ -478,7 +478,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        GenericCallParams(
+        GenericCall(
             gas=message_call_gas.sub_call,
             value=evm.message.value,
             caller=evm.message.caller,


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Companion PR to #2901 (EIP-8037), addressing the backport/refactor review comments so the `forks/osaka` to `forks/amsterdam` diff shows only genuine EIP-8037 changes.

### Backports

- **chore(spec-specs): move state fields to end of message call output** ([`f04b6a4`](https://github.com/spencer-tb/execution-specs/commit/f04b6a4af9e372738a1fd2418853343e4b5eb5d9))
  - Reorders `MessageCallOutput` so the four EIP-8037 fields append at the bottom, giving a clean append only diff against `forks/osaka` (the keyword argument conversion was already backported in #2238). Resolves [review comment](https://github.com/ethereum/execution-specs/pull/2901#discussion_r3313975270).
- **chore(spec-specs): backport intrinsic gas cost dataclass** ([`5f1b567`](https://github.com/spencer-tb/execution-specs/commit/5f1b567d5ac76fd6b5cf2b9ed2f069bd2defe10a))
  - Replaces the `(intrinsic_gas, calldata_floor)` tuple from `calculate_intrinsic_cost`/`validate_transaction` with an `IntrinsicGasCost` dataclass in the tuple returning forks (Prague, Osaka, BPO1 to BPO5), mirroring amsterdam minus its `state` field. Resolves [review comment](https://github.com/ethereum/execution-specs/pull/2901#discussion_r3313986317).
- **chore(spec-specs): backport calculate message call gas keyword arguments** ([`be445af`](https://github.com/spencer-tb/execution-specs/commit/be445af41f3eaa39a05227074aa3f336c73d0596))
  - Converts the `call()` invocation of `calculate_message_call_gas` from positional to keyword arguments across Tangerine Whistle to BPO5, so amsterdam's switch to keyword form reads as a value only diff. Resolves [review comment](https://github.com/ethereum/execution-specs/pull/2901#discussion_r3335895316).
- **chore(spec-specs): add generic call params dataclass for generic call** ([`97e342e`](https://github.com/spencer-tb/execution-specs/commit/97e342ec4014f79832320ff12b3dc66cea5269eb))
  - Bundles `generic_call`'s long positional argument list into a per fork `GenericCallParams` dataclass across all 24 forks. Resolves [review comment](https://github.com/ethereum/execution-specs/pull/2901#discussion_r3313879607).

### Refactors

- **chore(spec-specs): inline the sstore state gas constant** ([`5f3144d`](https://github.com/spencer-tb/execution-specs/commit/5f3144de619ccf1c3ec69562021923e37723d0ac))
  - Drops the redundant `state_gas_storage_set` local in `sstore` and uses `StateGasCosts.STORAGE_SET` directly (amsterdam only). Resolves [review comment](https://github.com/ethereum/execution-specs/pull/2901#discussion_r3335777919) (and [suggestion](https://github.com/ethereum/execution-specs/pull/2901#discussion_r3335780164)).
- **chore(spec-specs): split sstore regular and state gas** ([`ade3f44`](https://github.com/spencer-tb/execution-specs/commit/ade3f444942e540e0522a97d8692a8df0390ffeb))
  - Separates `sstore`'s state gas updates into their own `if` stack and lifts `credit_state_gas_refund` out of the nested refund branch (amsterdam only). Resolves [review comment](https://github.com/ethereum/execution-specs/pull/2901#discussion_r3313832897).
- **chore(spec-specs): trim state gas costs docstring** ([`3754685`](https://github.com/spencer-tb/execution-specs/commit/375468529abb511f0ca420d2e60e3b25add5d567))
  - Moves the "patched at runtime" implementation detail out of the `StateGasCosts` docstring into a comment above the class (amsterdam only). Resolves [review comment](https://github.com/ethereum/execution-specs/pull/2901#discussion_r3335923996).

### Explicitly Unchanged

Merging `charge_state_gas` into `charge_gas`? Should the two functions be folded into a single `charge_gas(evm, *, regular, state)`?

The decision was to keep it as 2 separate functions so each function emits its own EIP-3155 trace event `GasAndRefund` & `StateGasAndRefund`. We can reopen this question once tracing is consolidated in a follow up PR.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fmedia4.giphy.com%2Fmedia%2FxT0xeMDhLsyFwrjvBS%2Fgiphy.gif&f=1&nofb=1&ipt=666a46bb23dd6ff16d95b6e360ed33c6bdbbe9442dd1096a9a5408b4460b5d39)
