### PR TITLE
docs(tests): clarify gas-cap semantics and SSTORE stub layout assumption

### DIFF
--- a/packages/testing/src/execution_testing/tools/tools_code/generators.py
+++ b/packages/testing/src/execution_testing/tools/tools_code/generators.py
@@ -1103,8 +1103,10 @@ class IteratingBytecode(Bytecode):
 
         If the fork's transaction gas limit cap is not `None`, the returned
         list will contain one item per transaction that represents the
-        iteration count for that transaction, and no transaction will exceed
-        the gas limit cap.
+        iteration count for that transaction. The cap constrains each
+        transaction's compute gas; on forks with state gas (EIP-8037) the
+        transaction's combined gas limit may exceed the cap by the
+        state-gas portion.
         """
         gas_limit_cap = fork.transaction_gas_limit_cap()
         remaining_gas = gas_limit
@@ -1166,6 +1168,9 @@ class IteratingBytecode(Bytecode):
 
         while remaining_iterations > 0:
             if best_iterations is None or not constant_intrinsic_gas_cost:
+                # No block budget in this context, so the cap also bounds
+                # the combined gas to keep the search finite; under state
+                # gas (EIP-8037) this slightly under-fills transactions.
                 best_iterations, _ = self._binary_search_iterations(
                     fork=fork,
                     gas_limit=gas_limit_cap,

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -612,6 +612,11 @@ def test_sstore_bloated(
 ) -> None:
     """
     Benchmark SSTORE opcodes targeting an EOA with storage bloated.
+
+    The bloated storage is assumed to be filled linearly from slot 1
+    upwards, with each slot holding its own key as value. The SSTORE gas
+    metadata for `existing_slots=True` relies on this layout; if the stub
+    account deviates, the test will not exercise the claimed gas case.
     """
     sstore_metadata: dict[str, Any] = {}
     # If CACHE_TX, there would be one cold SLOAD before SSTORE


### PR DESCRIPTION
Debugging PR for the #2977 follow-up, based on the upstream PR head (18b0fbb). Shows only the follow-up changes before the real PR against upstream forks/amsterdam.

- `tx_iterations_by_gas_limit` docstring: the tx gas-limit cap constrains compute gas; under EIP-8037 the combined gas limit may exceed it by the state-gas portion.
- `test_sstore_bloated` docstring: restore the linear value==key stub storage layout assumption that `existing_slots=True` gas metadata relies on.
- `tx_iterations_by_total_iteration_count`: comment why the cap also bounds combined gas (no block budget in this context; keeps the search finite, slightly under-fills under state gas).