### PR TITLE
chore(spec-specs): delay `get_code` calls in CALL opcodes

### DIFF
--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -293,7 +293,6 @@ def generic_call(
     memory_input_size: U256,
     memory_output_start_position: U256,
     memory_output_size: U256,
-    code: Bytes,
     disable_precompiles: bool,
 ) -> None:
     """
@@ -307,6 +306,10 @@ def generic_call(
         evm.gas_left += gas
         push(evm.stack, U256(0))
         return
+
+    tx_state = evm.message.tx_env.state
+    code_hash = get_account(tx_state, code_address).code_hash
+    code = get_code(tx_state, code_hash)
 
     call_data = memory_read_bytes(
         evm.memory, memory_input_start_position, memory_input_size
@@ -419,9 +422,6 @@ def call(evm: Evm) -> None:
         if code_address not in evm.accessed_addresses:
             evm.accessed_addresses.add(code_address)
 
-    code_hash = get_account(tx_state, code_address).code_hash
-    code = get_code(tx_state, code_hash)
-
     message_call_gas = calculate_message_call_gas(
         value,
         gas,
@@ -452,7 +452,6 @@ def call(evm: Evm) -> None:
             memory_input_size,
             memory_output_start_position,
             memory_output_size,
-            code,
             is_delegated,
         )
 
@@ -523,9 +522,6 @@ def callcode(evm: Evm) -> None:
         if code_address not in evm.accessed_addresses:
             evm.accessed_addresses.add(code_address)
 
-    code_hash = get_account(tx_state, code_address).code_hash
-    code = get_code(tx_state, code_hash)
-
     message_call_gas = calculate_message_call_gas(
         value,
         gas,
@@ -557,7 +553,6 @@ def callcode(evm: Evm) -> None:
             memory_input_size,
             memory_output_start_position,
             memory_output_size,
-            code,
             is_delegated,
         )
 
@@ -666,7 +661,6 @@ def delegatecall(evm: Evm) -> None:
     check_gas(evm, access_gas_cost + extend_memory.cost)
 
     # STATE ACCESS
-    tx_state = evm.message.tx_env.state
     if is_cold_access:
         evm.accessed_addresses.add(code_address)
 
@@ -683,9 +677,6 @@ def delegatecall(evm: Evm) -> None:
         check_gas(evm, extra_gas + extend_memory.cost)
         if code_address not in evm.accessed_addresses:
             evm.accessed_addresses.add(code_address)
-
-    code_hash = get_account(tx_state, code_address).code_hash
-    code = get_code(tx_state, code_hash)
 
     message_call_gas = calculate_message_call_gas(
         U256(0),
@@ -711,7 +702,6 @@ def delegatecall(evm: Evm) -> None:
         memory_input_size,
         memory_output_start_position,
         memory_output_size,
-        code,
         is_delegated,
     )
 
@@ -756,7 +746,6 @@ def staticcall(evm: Evm) -> None:
     check_gas(evm, access_gas_cost + extend_memory.cost)
 
     # STATE ACCESS
-    tx_state = evm.message.tx_env.state
     if is_cold_access:
         evm.accessed_addresses.add(to)
 
@@ -773,9 +762,6 @@ def staticcall(evm: Evm) -> None:
         check_gas(evm, extra_gas + extend_memory.cost)
         if code_address not in evm.accessed_addresses:
             evm.accessed_addresses.add(code_address)
-
-    code_hash = get_account(tx_state, code_address).code_hash
-    code = get_code(tx_state, code_hash)
 
     message_call_gas = calculate_message_call_gas(
         U256(0),
@@ -801,7 +787,6 @@ def staticcall(evm: Evm) -> None:
         memory_input_size,
         memory_output_start_position,
         memory_output_size,
-        code,
         is_delegated,
     )
 


### PR DESCRIPTION
## 🗒️ Description

Delay `get_code` calls in CALL opcodes until after gas charging and the stack-depth check, so code is only fetched once the call is actually entered.

## 🔗 Related Issues or PRs
Copies ethereum/execution-specs#2473

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Famazinganimalphotos.com%2Fwp-content%2Fuploads%2F2019%2F07%2Fgifs-2020-10.gif&f=1&nofb=1&ipt=31b707c4a3ae830c1fa0b5c79c43e44902b2e5313fd7ef2dc0988ec34a275ad7)
