### PR TITLE
refactor(docs): replace docs-spec-parallel bash with a Python planner

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -316,9 +316,7 @@ docs-spec $DOCC_SKIP_DIFFS=env_var_or_default("DOCC_SKIP_DIFFS", ""):
 [group('docs')]
 docs-spec-fast: (docs-spec "1")
 
-# Validate spec docs quickly on PRs by building consecutive-fork shards
-# in parallel. Each shard overlaps its predecessor by one fork so a
-# fork's previous-fork references resolve. Per-shard output, not merged.
+# Build spec docs in parallel shards for fast PR validation
 [group('docs')]
 docs-spec-parallel shards="4":
     uv run python -m ethereum_spec_tools.docc_shards \

--- a/Justfile
+++ b/Justfile
@@ -316,36 +316,13 @@ docs-spec $DOCC_SKIP_DIFFS=env_var_or_default("DOCC_SKIP_DIFFS", ""):
 [group('docs')]
 docs-spec-fast: (docs-spec "1")
 
-# Build spec docs in parallel shards of consecutive forks (PR validation).
-# Each shard overlaps its predecessor fork by one so every previous-fork
-# reference is validated in some shard; outputs are per-shard and not merged.
+# Validate spec docs quickly on PRs by building consecutive-fork shards
+# in parallel. Each shard overlaps its predecessor by one fork so a
+# fork's previous-fork references resolve. Per-shard output, not merged.
 [group('docs')]
 docs-spec-parallel shards="4":
-    #!/usr/bin/env bash
-    set -euo pipefail
-    read -ra forks <<< "$(uv run python -c 'from ethereum_spec_tools.forks import Hardfork; print(" ".join(h.short_name for h in Hardfork.discover()))')"
-    total=${#forks[@]}
-    n={{ shards }}
-    per=$(( (total + n - 1) / n ))
-    pids=()
-    for ((i = 0; i < n; i++)); do
-        start=$(( i * per ))
-        [ "$start" -ge "$total" ] && break
-        end=$(( start + per ))
-        [ "$end" -gt "$total" ] && end=$total
-        s=$start
-        [ "$s" -gt 0 ] && s=$(( s - 1 ))
-        shard=$(IFS=,; echo "${forks[*]:$s:$(( end - s ))}")
-        echo "shard $i: $shard"
-        DOCC_SKIP_DIFFS=1 DOCC_ONLY_FORKS="$shard" \
-            uv run docc --output "{{ output_dir }}/docs-spec-parallel/shard-$i" &
-        pids+=($!)
-    done
-    fail=0
-    for pid in "${pids[@]}"; do
-        wait "$pid" || fail=1
-    done
-    exit $fail
+    uv run python -m ethereum_spec_tools.docc_shards \
+        -n {{ shards }} -o "{{ output_dir }}/docs-spec-parallel"
 
 # Build HTML site documentation with mkdocs
 [group('docs')]

--- a/packages/testing/src/execution_testing/cli/pytest_commands/fill.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/fill.py
@@ -140,6 +140,7 @@ class FillCommand(PytestCommand):
         """Add default ignore paths for directories not used by fill."""
         # Directories to ignore by default
         default_ignores = [
+            "tests/docc",
             "tests/evm_tools",
             "tests/json_loader",
             "tests/fixtures",

--- a/src/ethereum_spec_tools/docc_shards.py
+++ b/src/ethereum_spec_tools/docc_shards.py
@@ -1,0 +1,83 @@
+"""
+Build the docc spec docs as parallel shards of consecutive forks.
+
+Fast PR-time validation only: the fork range is split into ``n``
+contiguous shards, each overlapping its predecessor by one fork so a
+fork's reference to the previous fork resolves within its shard. One
+``docc`` process renders each shard concurrently; the per-shard outputs
+are not merged.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import List
+
+from .forks import Hardfork
+
+
+def compute_shards(forks: List[str], n: int) -> List[List[str]]:
+    """
+    Split ``forks`` into at most ``n`` contiguous shards.
+
+    Every shard after the first is prefixed with its predecessor fork, so
+    a fork's reference to the previous fork resolves within its shard.
+    """
+    per = (len(forks) + n - 1) // n
+    shards: List[List[str]] = []
+    for i in range(n):
+        start = i * per
+        if start >= len(forks):
+            break
+        lo = start - 1 if start > 0 else start
+        shards.append(forks[lo : min(start + per, len(forks))])
+    return shards
+
+
+def main() -> int:
+    """Discover forks, shard them, and render each shard with ``docc``."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-n",
+        "--shards",
+        type=int,
+        default=4,
+        help="number of parallel shards (default: 4)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="parent directory for each shard's output",
+    )
+    args = parser.parse_args()
+    if args.shards < 1:
+        parser.error("--shards must be a positive integer")
+
+    forks = [fork.short_name for fork in Hardfork.discover()]
+    if not forks:
+        print("error: no forks discovered", file=sys.stderr)
+        return 1
+
+    processes: List[subprocess.Popen[bytes]] = []
+    for i, shard in enumerate(compute_shards(forks, args.shards)):
+        print(f"shard {i}: {','.join(shard)}", flush=True)
+        env = {
+            **os.environ,
+            "DOCC_SKIP_DIFFS": "1",
+            "DOCC_ONLY_FORKS": ",".join(shard),
+        }
+        output = args.output_dir / f"shard-{i}"
+        processes.append(
+            subprocess.Popen(["docc", "--output", str(output)], env=env)
+        )
+
+    exit_codes = [process.wait() for process in processes]
+    return 1 if any(exit_codes) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/docc/test_docc_shards.py
+++ b/tests/docc/test_docc_shards.py
@@ -1,0 +1,50 @@
+"""
+Unit tests for the parallel spec-doc shard planner.
+"""
+
+from ethereum_spec_tools.docc_shards import compute_shards
+from ethereum_spec_tools.forks import Hardfork
+
+
+def test_shards_cover_every_fork() -> None:
+    """Every fork lands in at least one shard."""
+    forks = [f"f{i}" for i in range(24)]
+    shards = compute_shards(forks, 4)
+    covered = {fork for shard in shards for fork in shard}
+    assert covered == set(forks)
+
+
+def test_shards_are_contiguous_with_one_fork_overlap() -> None:
+    """Shards tile the range in order, overlapping one fork per seam."""
+    forks = [f"f{i}" for i in range(24)]
+    assert compute_shards(forks, 4) == [
+        forks[0:6],
+        forks[5:12],
+        forks[11:18],
+        forks[17:24],
+    ]
+
+
+def test_each_fork_shares_a_shard_with_its_predecessor() -> None:
+    """The overlap keeps every fork beside its immediate predecessor."""
+    forks = [f"f{i}" for i in range(24)]
+    shards = compute_shards(forks, 4)
+    for i in range(1, len(forks)):
+        assert any(
+            forks[i] in shard and forks[i - 1] in shard for shard in shards
+        )
+
+
+def test_more_shards_than_forks_still_covers_all() -> None:
+    """Requesting more shards than forks leaves no fork uncovered."""
+    shards = compute_shards(["a", "b", "c"], 4)
+    covered = {fork for shard in shards for fork in shard}
+    assert covered == {"a", "b", "c"}
+
+
+def test_real_fork_set_is_fully_covered() -> None:
+    """The discovered fork set shards without dropping any fork."""
+    forks = [fork.short_name for fork in Hardfork.discover()]
+    shards = compute_shards(forks, 4)
+    covered = {fork for shard in shards for fork in shard}
+    assert covered == set(forks)


### PR DESCRIPTION
## 🗒️ Description

Follow-up to the `docs-spec-parallel` recipe added in #3101. It moves the shard math and process fan-out out of the inline bash block into `ethereum_spec_tools.docc_shards`, invoked via `python -m`, leaving the recipe a one-line delegation. The integer sharding, array slicing, and subprocess handling read far more clearly in Python, and the shard planner (`compute_shards`) is now unit tested. A successful build is unchanged: Identical shards, identical per-shard output under `docs-spec-parallel/shard-N`.

The move also resolves three review points at no extra cost. It exits non-zero when fork discovery returns nothing, where the bash form exited `0` having validated nothing (a false green on a validation gate); it unit tests the coverage and one-fork-overlap invariants that were previously only eyeballed in bash; and it runs as a module rather than a console script, so nothing new lands on local users' `PATH`.

## 🔗 Related Issues or PRs

Builds on #3101.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) and [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/):
    ```console
    just static
    ```
- [x] All: PR title have the form `<type>(<area>):`, where `<type>` and `<area>` come from an approrpriate `C-<type>`, respectively `A-<area>`, label. The title should match the a target squash commit message.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![cat](https://cataas.com/cat/gif)
