### PR TITLE
Eips/glamsterdam/eip 8037 charge at access

### DIFF
--- a/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8037.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/amsterdam/eip_8037.py
@@ -356,13 +356,14 @@ class EIP8037(BaseFork):
     ) -> int:
         """
         Calculate the CREATE and CREATE2 state gas cost, which is
-        `NEW_ACCOUNT`. Before EIP-8037 this was folded into
-        `OPCODE_CREATE_BASE`. Under EIP-8037 it is exposed here so that
-        `OPCODE_CREATE_BASE` stays regular only and matches the spec
-        EVM constant.
+        `NEW_ACCOUNT` (if the account did not exist before).
+        Before EIP-8037 this was folded into `OPCODE_CREATE_BASE`. Under
+        EIP-8037 it is exposed here so that `OPCODE_CREATE_BASE` stays regular
+        only and matches the spec EVM constant.
         """
-        del opcode
-        return gas_costs.NEW_ACCOUNT
+        if opcode.metadata["account_new"]:
+            return gas_costs.NEW_ACCOUNT
+        return 0
 
     @classmethod
     def _calculate_selfdestruct_state_gas(

--- a/packages/testing/src/execution_testing/vm/opcodes.py
+++ b/packages/testing/src/execution_testing/vm/opcodes.py
@@ -5381,6 +5381,7 @@ class Opcodes(Opcode, Enum):
             "init_code_size": 0,
             "new_memory_size": 0,
             "old_memory_size": 0,
+            "account_new": True,
         },
     )
     """
@@ -5718,6 +5719,7 @@ class Opcodes(Opcode, Enum):
             "init_code_size": 0,
             "new_memory_size": 0,
             "old_memory_size": 0,
+            "account_new": True,
         },
     )
     """

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_opcodes.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_opcodes.py
@@ -3298,10 +3298,8 @@ def test_bal_create_and_oog(
     CREATE/CREATE2 OOG boundary test at three gas levels.
 
     OOG_BEFORE_TARGET_ACCESS and OOG_AFTER_TARGET_ACCESS differ by
-    exactly 1 gas, proving the pre-access cost boundary: below it the
-    created address is NOT in BAL, at it the address IS in BAL. Under
-    EIP-8037 charge-at-access this boundary excludes NEW_ACCOUNT, which
-    is charged at the access rather than before it.
+    exactly 1 gas, proving the static cost boundary: below it the
+    created address is NOT in BAL, at it the address IS in BAL.
     """
     alice = pre.fund_eoa()
 
@@ -3316,6 +3314,7 @@ def test_bal_create_and_oog(
         offset=32 - len(init_code_bytes),
         size=len(init_code_bytes),
         init_code_size=len(init_code_bytes),
+        account_new=False,
     )
     factory_sstore = Op.SSTORE(0x00, 1)
     oog_sink_memory_size = 10000 * 32
@@ -3341,24 +3340,21 @@ def test_bal_create_and_oog(
         initcode=init_code_bytes,
         opcode=create_opcode,
     )
+    # Pre-fund the address so no new account is created
+    pre.fund_address(created_address, 1)
 
     intrinsic_cost = fork.transaction_intrinsic_cost_calculator()()
     create_static_cost = factory_mstore.gas_cost(
         fork
     ) + factory_create.gas_cost(fork)
-    # Under EIP-8037 charge-at-access the NEW_ACCOUNT state gas is charged
-    # at the destination access, not before it, so the pre-access cost that
-    # gates whether the address is read excludes it. `gas_cost` folds
-    # NEW_ACCOUNT into the create opcode total, so strip it back out.
-    pre_access_cost = create_static_cost - fork.gas_costs().NEW_ACCOUNT
 
     if oog_boundary == OutOfGasBoundary.OOG_BEFORE_TARGET_ACCESS:
-        # 1 gas short of the pre-access cost — no state access
-        gas_limit = intrinsic_cost + pre_access_cost - 1
+        # 1 gas short of CREATE static cost — no state access
+        gas_limit = intrinsic_cost + create_static_cost - 1
     elif oog_boundary == OutOfGasBoundary.OOG_AFTER_TARGET_ACCESS:
-        # Exactly the pre-access cost — address accessed, then the
-        # NEW_ACCOUNT charge OOGs after access
-        gas_limit = intrinsic_cost + pre_access_cost
+        # Exactly the CREATE static cost — address accessed, child
+        # frame gets 0 gas, CREATE fails, sink forces OOG after access
+        gas_limit = intrinsic_cost + create_static_cost
     else:
         # Full success: static cost + child frame (63/64 rule) +
         # SSTORE + gas sink.
@@ -3395,7 +3391,7 @@ def test_bal_create_and_oog(
         post = {
             alice: Account(nonce=1),
             factory: Account(nonce=1, storage={0x00: 0xDEAD}),
-            created_address: Account.NONEXISTENT,
+            created_address: Account(balance=1, code=b"", nonce=0),
         }
     elif oog_boundary == OutOfGasBoundary.OOG_AFTER_TARGET_ACCESS:
         # Created address IS in BAL (accessed during collision check),
@@ -3413,7 +3409,7 @@ def test_bal_create_and_oog(
         post = {
             alice: Account(nonce=1),
             factory: Account(nonce=1, storage={0x00: 0xDEAD}),
-            created_address: Account.NONEXISTENT,
+            created_address: Account(balance=1, code=b"", nonce=0),
         }
     else:
         # SUCCESS: created address in BAL with nonce and code changes
@@ -3453,7 +3449,7 @@ def test_bal_create_and_oog(
         post = {
             alice: Account(nonce=1),
             factory: Account(nonce=2, storage={0x00: 1}),
-            created_address: Account(code=Op.STOP),
+            created_address: Account(balance=1, code=Op.STOP, nonce=1),
         }
 
     blockchain_test(

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -2899,73 +2899,50 @@ def test_create_collision_burned_gas_counted_in_block_regular(
     """
     init_code = Op.STOP
     mstore_value, size = init_code_at_high_bytes(init_code)
-    salt = 0
-
-    create_call = (
-        create_opcode(value=0, offset=0, size=size, salt=salt)
-        if create_opcode == Op.CREATE2
-        else create_opcode(value=0, offset=0, size=size)
-    )
-    factory_code = Op.MSTORE(0, mstore_value) + Op.POP(create_call) + Op.STOP
+    factory_create_code = Op.MSTORE(
+        0, mstore_value, new_memory_size=32
+    ) + create_opcode(value=0, offset=0, size=size, account_new=False)
+    factory_post_create_code = Op.POP + Op.STOP
+    factory_code = factory_create_code + factory_post_create_code
     factory = pre.deploy_contract(code=factory_code)
 
     collision_target = compute_create_address(
         address=factory,
         nonce=1,
-        salt=salt,
+        salt=0,
         initcode=bytes(init_code),
         opcode=create_opcode,
     )
     pre.deploy_contract(code=Op.STOP, address=collision_target)
-
-    # Fixed-size budget so the forwarded create_message_gas is
-    # deterministic and the baseline below is reproducible.
-    gas_limit = 250_000
-
-    tx = Transaction(
-        to=factory,
-        gas_limit=gas_limit,
-        sender=pre.fund_eoa(),
-    )
 
     # CPSB-agnostic baseline: block_state_gas is zero for this tx (the
     # existent collision target is not charged), so header.gas_used
     # equals the regular-gas total. Decompose the parent + inner frame
     # accounting from fork APIs so the baseline tracks future cost
     # changes automatically.
-    intrinsic = fork.transaction_intrinsic_cost_calculator()()
-    new_account = fork.gas_costs().NEW_ACCOUNT
-    create_base = fork.gas_costs().OPCODE_CREATE_BASE
-    # POP + STOP run in the parent frame after CREATE returns; their
-    # cost comes out of the 1/64 retained gas.
-    post_create_static = (Op.POP + Op.STOP).gas_cost(fork)
-    # factory_code.gas_cost(fork) folds NEW_ACCOUNT into the CREATE op
-    # (state gas is treated as part of the opcode total). Strip it
-    # back out and split off the post-CREATE tail to isolate the
-    # pre-CREATE static gas.
-    factory_pre_create = (
-        factory_code.gas_cost(fork)
-        - new_account
-        - create_base
-        - post_create_static
+    gas_used_until_collision = (
+        fork.transaction_intrinsic_cost_calculator()()
+        + factory_create_code.gas_cost(fork)
     )
-    # MSTORE writes the initcode at memory[0:32] (one word).
-    memory_expansion = fork.memory_expansion_gas_calculator()(new_bytes=32)
-    # gas_left at the CREATE split. The collision target is existent, so no
-    # account-creation charge is applied before the 63/64 split.
-    gas_at_create = (
-        gas_limit
-        - intrinsic
-        - factory_pre_create
-        - memory_expansion
-        - create_base
-    )
+    # Fixed-size budget so the forwarded create_message_gas is
+    # deterministic and the baseline below is reproducible.
+    gas_limit = gas_used_until_collision * 2
+    # Remaining gas can be derived due to the fixed gas limit
+    gas_at_create = gas_limit - gas_used_until_collision
     # Inner burns 63/64 of the available gas on collision; the parent
     # retains 1/64. Post-CREATE consumes from the retained pool. A
     # mutation that drops the burned forwarded gas from regular
     # accounting would reduce this baseline.
     retained = gas_at_create // 64
-    baseline_gas_used = gas_limit - retained + post_create_static
+    gas_post_create = factory_post_create_code.gas_cost(fork)
+    assert retained >= gas_post_create
+    baseline_gas_used = gas_limit - retained + gas_post_create
+
+    tx = Transaction(
+        to=factory,
+        gas_limit=gas_limit,
+        sender=pre.fund_eoa(),
+    )
 
     blockchain_test(
         pre=pre,


### PR DESCRIPTION
### Description
Makes `account_new` metadata information available for `CREATE*` opcodes.

Helps fork gas calculators add or subtract the new-account-created state gas cost.

By default the value is `True` (as opposed to the default value of `CALL*` for example) since this seems like the most sensible way of operation for tests using this opcode (it's normally expected that this opcode creates a new account).