### PR TITLE
feat(ci): add a dry_run input to rehearse the release pipeline

### DIFF
--- a/.github/workflows/release_fixtures.yaml
+++ b/.github/workflows/release_fixtures.yaml
@@ -1,6 +1,6 @@
 name: Create Fixture Release
 
-run-name: ${{ github.event_name == 'schedule' && 'Nightly Fill' || format('Create Fixture Release {0}@{1}', inputs.feature, inputs.version) }}
+run-name: ${{ github.event_name == 'schedule' && 'Nightly Fill' || inputs.dry_run && format('Dry Run {0}@{1}', inputs.feature, inputs.version) || format('Create Fixture Release {0}@{1}', inputs.feature, inputs.version) }}
 
 # Scheduled runs fill the mainnet `tests` feature (all tests, all fixture
 # formats, up to the latest mainnet fork -- no dev forks) through the exact
@@ -8,6 +8,12 @@ run-name: ${{ github.event_name == 'schedule' && 'Nightly Fill' || format('Creat
 # is created: a rotating, always-available artifact of the mainnet
 # fixtures. The cron fires at 02:00 UTC: the self-hosted runners are past
 # the EU/US daytime peaks and results are ready before the EU morning.
+#
+# A manual dispatch with `dry_run` follows the same no-release path for
+# any feature: the full pipeline runs, the `release` job is skipped and
+# nightly artifact retention applies. Dry runs are dispatch events, so
+# the nightly baseline in check_new_commits.py (which filters on
+# `event=schedule`) never counts them.
 on:
   schedule:
     - cron: "0 2 * * *"
@@ -37,11 +43,17 @@ on:
         description: "Override the t8n tool branch / tag / commit"
         required: false
         type: string
+      dry_run:
+        description: "Rehearse without releasing: skip the release job (no tag, no draft), use nightly retention."
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
-  # Scheduled runs queue behind an in-flight nightly (never cancel a fill);
-  # manual releases are unconstrained (each run gets a unique group).
-  group: ${{ github.event_name == 'schedule' && 'nightly-fill' || github.run_id }}
+  # Scheduled and dry runs queue behind an in-flight nightly-style run
+  # (never cancel a fill); manual releases are unconstrained (each run
+  # gets a unique group).
+  group: ${{ (github.event_name == 'schedule' || inputs.dry_run) && 'nightly-fill' || github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -98,8 +110,8 @@ jobs:
     timeout-minutes: 1440
     strategy:
       # A release must be complete, so abort on the first failed range; a
-      # nightly wants every range's result for debugging.
-      fail-fast: ${{ github.event_name != 'schedule' }}
+      # nightly or dry run wants every range's result for debugging.
+      fail-fast: ${{ github.event_name != 'schedule' && !inputs.dry_run }}
       matrix:
         include: ${{ fromJson(needs.setup.outputs.build_matrix) }}
     steps:
@@ -114,9 +126,10 @@ jobs:
           from_fork: ${{ matrix.from_fork }}
           until_fork: ${{ matrix.until_fork }}
           split_label: ${{ matrix.label }}
-          # Nightly splits are intermediates consumed by `combine` right
-          # away; don't retain them for the repo-default period.
-          split_retention_days: ${{ github.event_name == 'schedule' && '1' || '' }}
+          # Nightly and dry-run splits are intermediates consumed by
+          # `combine` right away; don't retain them for the repo-default
+          # period.
+          split_retention_days: ${{ (github.event_name == 'schedule' || inputs.dry_run) && '1' || '' }}
           evm: ${{ inputs.evm }}
           evm_repo: ${{ inputs.evm_repo }}
           evm_ref: ${{ inputs.evm_ref }}
@@ -183,17 +196,18 @@ jobs:
         with:
           name: fixtures_${{ needs.setup.outputs.feature_name }}
           path: ${{ steps.tarball.outputs.path }}
-          # Keep nightly tarballs for five days; a quiet nightly re-runs
-          # after four (see check_new_commits.py), so a live artifact
-          # always exists. Release tarballs keep the repo default since
-          # the release job attaches them to a draft release anyway.
-          retention-days: ${{ github.event_name == 'schedule' && '5' || '' }}
+          # Keep nightly (and dry-run) tarballs for five days; a quiet
+          # nightly re-runs after four (see check_new_commits.py), so a
+          # live artifact always exists. Release tarballs keep the repo
+          # default since the release job attaches them to a draft
+          # release anyway.
+          retention-days: ${{ (github.event_name == 'schedule' || inputs.dry_run) && '5' || '' }}
 
   release:
     runs-on: ubuntu-latest
     needs: [setup, build, combine]
-    # Scheduled runs stop after `combine`: no tag, no draft release.
-    if: always() && github.event_name == 'workflow_dispatch' && needs.build.result == 'success' && (needs.combine.result == 'success' || needs.combine.result == 'skipped')
+    # Scheduled and dry runs stop after `combine`: no tag, no draft release.
+    if: always() && github.event_name == 'workflow_dispatch' && !inputs.dry_run && needs.build.result == 'success' && (needs.combine.result == 'success' || needs.combine.result == 'skipped')
     permissions:
       contents: write
     steps:

--- a/docs/dev/releasing_tests.md
+++ b/docs/dev/releasing_tests.md
@@ -23,6 +23,7 @@ gh workflow run release_fixtures.yaml -f feature=<feature> -f version=vX.Y.Z [-f
 | `evm`      | no                | Override the evm impl (e.g. `geth`, `evmone`). Defaults to the feature's `evm-type` in `feature.yaml`. |
 | `evm_repo` | no                | Override the t8n tool repo (e.g. `ethereum/go-ethereum`).                                              |
 | `evm_ref`  | no                | Override the t8n tool branch / tag / commit.                                                          |
+| `dry_run`  | no                | Run the full pipeline but skip the `release` job (no tag, no draft release) and apply the nightly artifact retention: a manual rehearsal of the nightly/release path for any feature. |
 
 `<feature>` must be a key in
 [`.github/configs/feature.yaml`](https://github.com/ethereum/execution-specs/blob/master/.github/configs/feature.yaml)


### PR DESCRIPTION
## 🗒️ Description

The schedule path keys entirely on `github.event_name == 'schedule'` and cannot run in PR CI, so the first real execution of the merged nightly behavior would be the 02:00 cron itself. This adds a `dry_run` boolean dispatch input that follows the same no-release path from the Actions UI: the `release` job is skipped (no tag, no draft), `fail-fast` is off so every fork range reports, nightly artifact retention applies, and the run queues in the `nightly-fill` concurrency group. Dry runs are dispatch events, so the nightly baseline in `check_new_commits.py` (filtered on `event=schedule`) never counts them, and #31's promotion can never select their artifacts. Composes with any `feature`, so benchmark and devnet releases can be rehearsed end-to-end too.

## 🔗 Related Issues or PRs

Targets the head branch of ethereum/execution-specs#3100; complements #31.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) and [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/):
    ```console
    just static
    ```
- [x] All: PR title have the form `<type>(<area>):`, where `<type>` and `<area>` come from an approrpriate `C-<type>`, respectively `A-<area>`, label. The title should match the a target squash commit message.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.

#### Cute Animal Picture

![just a rehearsal](https://cataas.com/cat/says/just%20a%20rehearsal?fontSize=40&fontColor=white)
